### PR TITLE
docs: remove stale repository references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ coverage/
 .turbo/
 *.log
 *.tgz
-poc/
 .env
 !apps/cli/tests/fixtures/env/.env
 

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,14 +10,7 @@
   "bracketSameLine": false,
   "arrowParens": "avoid",
   "endOfLine": "lf",
-  "ignorePatterns": [
-    "**/node_modules/**",
-    "**/.turbo/**",
-    "**/dist/**",
-    "**/coverage/**",
-    "**/package-lock.json",
-    "poc/**"
-  ],
+  "ignorePatterns": ["**/node_modules/**", "**/.turbo/**", "**/dist/**", "**/coverage/**", "**/package-lock.json"],
   "overrides": [
     {
       "files": ["*.json"],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,7 +10,7 @@
   "env": {
     "es2024": true
   },
-  "ignorePatterns": ["**/node_modules/**", "**/.turbo/**", "**/dist/**", "**/coverage/**", "poc/**"],
+  "ignorePatterns": ["**/node_modules/**", "**/.turbo/**", "**/dist/**", "**/coverage/**"],
   "rules": {
     "eslint/no-unused-vars": "warn",
     "typescript/no-unused-vars": "warn",

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ sdk/        @aml-jsx/sdk, the AML runtime and public API
 providers/  optional Agent, Sandbox, and Workspace provider implementations
 apps/       runnable products built on AML (website: the project site)
 examples/   human-readable client workflows
-poc/        archived Phase 0 experiments and research
 ```
 
 [`SPEC.md`](./SPEC.md) is the normative behavior contract. [`PRD.md`](./PRD.md) records product decisions, architecture, and delivery status. [`PROVIDERS.md`](./PROVIDERS.md) tracks the provider implementation wishlist.
@@ -425,7 +424,7 @@ apps/website/src/
   data/                        typed navigation, provider, and homepage content
   content/docs/                Starlight documentation source
   components/docs/             shared Starlight layout, provider, and page-action UI
-  pages/docs/[...path].md.ts    per-page Markdown alternatives
+  plugins/docs-markdown/        per-page Markdown route and rendering
   pages/docs/llms.txt.ts        complete concatenated documentation
   styles/                      global Starlight layout and content rhythm
 ```

--- a/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
@@ -137,4 +137,3 @@ The important observable behavior is session shape: the provider receives one in
 - [`<FollowUp />`](/docs/reference/primitives/follow-up/)
 - [Maintained FollowUp example](https://github.com/we-are-singular/aml/blob/main/examples/src/core/follow-up.tsx)
 - [FollowUp specification](https://github.com/we-are-singular/aml/blob/main/SPEC.md#6-followup)
-- Adapted from the local editorial source `marketing/examples/012-deliberate-editorial-passes.md`; the public contract is verified against the implementation and specification links above.

--- a/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
@@ -129,7 +129,7 @@ The important observable behavior is session shape: the provider receives one in
 - Add a final structured-output boundary only if the provider supports it for the final turn; earlier FollowUp responses remain session history rather than typed host values.
 - For independent reviewers, use separate `evaluate()` calls and explicit JavaScript concurrency instead of placing parallel work in one `<FollowUp />` chain.
 
-## References
+## API and source links
 
 - [Agent provider boundary](/docs/reference/providers/#agent)
 - [FollowUp and runtime reference](/docs/reference/runtime/)

--- a/apps/website/src/content/docs/docs/cookbook/generated-diagnostic.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/generated-diagnostic.mdx
@@ -137,7 +137,7 @@ The final `<Agent />` receives that line as ordinary prompt data. Docker Sandbox
 - Add a schema or ordinary TypeScript validator for the generated source and output when the diagnostic has a stricter contract. Shape validation still does not establish authorization or factual correctness.
 - Wrap the Sandbox in a Workspace when the workflow must materialize or reconcile files. A Sandbox lease alone is not durable persistence.
 
-## References
+## API and source links
 
 - [Sandbox provider boundary](/docs/reference/providers/#sandbox)
 - [Docker Sandbox provider](/docs/providers/sandboxes/docker/)

--- a/apps/website/src/content/docs/docs/cookbook/generated-diagnostic.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/generated-diagnostic.mdx
@@ -145,4 +145,3 @@ The final `<Agent />` receives that line as ordinary prompt data. Docker Sandbox
 - [`<Script />`](/docs/reference/primitives/script/)
 - [`dockerSandbox` implementation](https://github.com/we-are-singular/aml/blob/main/providers/sandboxes/docker/src/docker-sandbox.ts)
 - [Maintained Docker example](https://github.com/we-are-singular/aml/blob/main/examples/src/integrations/docker.tsx)
-- Adapted from the local editorial source `marketing/examples/001-generated-diagnostic-pipeline.md`; the public contract is verified against the implementation links above.

--- a/apps/website/src/content/docs/docs/cookbook/index.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/index.mdx
@@ -41,6 +41,9 @@ The recipe status tells you what the source actually does:
 - <Badge text="Resource-backed" variant="note" /> exercises a local, container, or remote filesystem/execution boundary.
   Read its mutation and isolation notes before running it.
 
+Recipe steps and claims are verified against the implementation and specification links in each page's API and
+source links section.
+
 ## Learn the workflow shape
 
 <CardGrid>

--- a/apps/website/src/content/docs/docs/cookbook/structured-routing.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/structured-routing.mdx
@@ -167,7 +167,7 @@ If the route points outside the canonical root, resolves to the root itself, or 
 - Use `filesystemWorkspace()` or `s3Workspace()` when the handoff needs revision history or remote persistence; read their lock, retention, and conditional-publication contracts first.
 - Add `<Sandbox />` around the later `<Agent />` when playbook work involves commands. The Workspace boundary persists files; it does not make execution safe.
 
-## References
+## API and source links
 
 - [Structured output recipe](/docs/cookbook/structured-output/)
 - [Local Workspace provider](/docs/providers/workspaces/local/)

--- a/apps/website/src/content/docs/docs/cookbook/structured-routing.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/structured-routing.mdx
@@ -175,4 +175,3 @@ If the route points outside the canonical root, resolves to the root itself, or 
 - [Workspace provider boundary](/docs/reference/providers/#workspace)
 - [`evaluate()`](/docs/reference/runtime/#component-local-evaluation)
 - [Maintained routing example](https://github.com/we-are-singular/aml/blob/main/examples/src/integrations/workspace-routing.tsx)
-- Adapted from the local editorial source `marketing/examples/007-structured-routing.md`; the public contract is verified against the maintained routing example and provider references above.


### PR DESCRIPTION
## What changed
- removes the nonexistent ignored `poc/` directory from the repository layout
- points the website layout at the actual injected Markdown-route plugin
- removes three cookbook provenance bullets that cite files never tracked in the repository
- drops the now-dead `poc/` ignore patterns from `.gitignore`, `.oxlintrc.json`, and `.oxfmtrc.json`
- preserves the cookbook contract-verification claim in a shared note on the cookbook index and renames the affected pages' reference sections to the documented `API and source links` convention

## Evidence
The removed paths are absent from the working tree and Git history. The actual Markdown alternatives are implemented by `apps/website/src/plugins/docs-markdown/`, and the maintained implementation links in each cookbook remain intact.

## Validation
- `npm run format:check`
- `npm run lint --workspace=@aml-jsx/website`
- `npm run build --workspace=@aml-jsx/website` (75 pages)
- `git diff --check`
- full pre-push gate (`format:check`, `lint`, `test`, `build` across all workspaces)

## Notes
The baseline Astro 5 deprecation warning remains on this independent branch and is addressed by #3. No ambiguous files were deleted.

---

Old paths leave no trace  
The map names what is present  
Readers find firm ground
