### PR TITLE
fix(agent-sandbox): repair stable release verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The credentialed smoke runner exercises the complete built-in Agent × Sandbox m
 
 Every cell launches its Agent through the same shared ACP engine and `SandboxRuntime.spawn()`. These proofs use read-write Workspaces where a provider cannot enforce read-only access. The selected host, image, or snapshot must contain the required executable. Sandbox providers do not install Agents implicitly.
 
-Docker, Daytona, and Modal smoke cells use `ghcr.io/we-are-singular/aml-agent-sandbox:dev`, which contains the matrix's pinned Agent executables. Provider factories default to `wearesingular/aml-agent-sandbox:latest`; applications can override that mutable convenience tag with their own image, snapshot, immutable version, or digest.
+Docker, Daytona, and Modal smoke cells use `ghcr.io/we-are-singular/aml-agent-sandbox:dev`, which contains the matrix's pinned Agent executables. Set `AML_SMOKE_SANDBOX_IMAGE` to run every image-backed cell against one explicit reference, such as an immutable stable digest. Provider factories default to `wearesingular/aml-agent-sandbox:latest`; applications can override that mutable convenience tag with their own image, snapshot, immutable version, or digest.
 
 `<System>`, `<Skill>`, `<FollowUp>`, Context, and tree evaluation are runtime-owned. JavaScript Tools use one AML-owned invocation MCP bridge, and structured output uses one AML-owned final-turn submission Tool. Agent permissions default to read-write filesystem, shell, and network access; the active Sandbox remains the security boundary for model-controlled operations.
 

--- a/images/aml-agent-sandbox/.release-it.json
+++ b/images/aml-agent-sandbox/.release-it.json
@@ -3,7 +3,7 @@
   "verbose": true,
   "hooks": {
     "after:bump": ["npm install --package-lock-only --ignore-scripts", "git add package-lock.json"],
-    "before:release": ["node scripts/publish.mjs --check", "npm run release:check"],
+    "before:release": "npm run release:check",
     "after:git:release": "node scripts/publish.mjs ${version}"
   },
   "git": {

--- a/images/aml-agent-sandbox/README.md
+++ b/images/aml-agent-sandbox/README.md
@@ -98,11 +98,18 @@ Stable image releases run locally, not in GitHub Actions. Start from a clean `ma
 npm run release:docker
 ```
 
-The command opens Docker Hub's browser login in a temporary Docker configuration. The temporary credentials are
-deleted when the command exits. Release It then prompts for the version, runs the image audit/build/conformance checks,
+The command first checks that the caller's selected Buildx builder can publish SBOM and provenance attestations. Use an
+existing `docker-container` builder, or enable Docker's containerd image store; the release does not create or switch
+builders. Docker Hub's browser login then uses a temporary Docker configuration while the caller's Buildx configuration,
+selected builder, and state remain available. The temporary credentials are deleted when the command exits. Release It
+then prompts for the version, runs the image audit/build/conformance checks,
 creates a `docker-vX.Y.Z` release commit and tag, publishes the image to Docker Hub, verifies its digest, and signs that
 digest. The active `gh` account authorizes the source tag's GitHub Release; it is not used to publish a stable GHCR
 image.
+
+Browser authentication follows each maintainer's local setup. Under WSL, set `BROWSER` to an installed host-browser
+opener such as `wslview`, or open the displayed device URL in Windows and enter the one-time code. Native Linux and
+macOS maintainers can keep their normal browser configuration. No browser path is required by the release scripts.
 
 If image publication fails after Release It creates the release commit and tag, recover that same version from a clean `main` checkout:
 
@@ -117,6 +124,18 @@ Preview the versioning and Git release flow without publishing:
 ```sh
 npm run release:docker -- --dry-run
 ```
+
+After publication completes, independently verify the immutable digest, exact Cosign signer policy, BuildKit SBOM and
+provenance, all stable tags, and the GitHub Release:
+
+```sh
+npm run verify:release --prefix images/aml-agent-sandbox -- 0.1.0 sha256:<digest> \
+  --certificate-identity '<exact Fulcio certificate identity>' \
+  --certificate-oidc-issuer 'https://github.com/login/oauth'
+```
+
+Use the signer identity approved for the maintainer who performed the local keyless signing. The verifier requires an
+exact identity and issuer; it does not accept wildcard trust policy.
 
 ## Channels, tags, and platforms
 

--- a/images/aml-agent-sandbox/package.json
+++ b/images/aml-agent-sandbox/package.json
@@ -13,7 +13,9 @@
     "build": "docker build --platform linux/amd64 --tag aml-agent-sandbox:dev .",
     "check": "docker run --rm --platform linux/amd64 --volume $PWD/verify.sh:/verify.sh:ro aml-agent-sandbox:dev /verify.sh",
     "release": "node scripts/release.mjs",
-    "release:check": "npm audit --omit=dev && npm run build && npm run check"
+    "release:check": "npm audit --omit=dev && npm run build && npm run check",
+    "test": "node --test scripts/*.test.mjs",
+    "verify:release": "node scripts/verify-release.mjs"
   },
   "dependencies": {
     "@agentclientprotocol/codex-acp": "1.4.0",

--- a/images/aml-agent-sandbox/scripts/publish.mjs
+++ b/images/aml-agent-sandbox/scripts/publish.mjs
@@ -3,76 +3,81 @@ import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import process from "node:process"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const imageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const repositoryRoot = resolve(imageDirectory, "../..")
 const dockerHubImage = "docker.io/wearesingular/aml-agent-sandbox"
 const version = process.argv[2]
 
-if (version === "--check") {
-  requireCommand("docker", ["buildx", "version"])
-  requireCommand("cosign", ["version"])
-  process.stdout.write("Docker image publishing tools are available\n")
-  process.exit(0)
-}
-
-if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version ?? "")) {
-  throw new Error("Expected a semantic version argument")
-}
-
-const packageVersion = JSON.parse(readFileSync(join(imageDirectory, "package.json"), "utf8")).version
-if (packageVersion !== version) {
-  throw new Error(`Release version ${version} does not match package version ${packageVersion}`)
-}
-
-const revision = output("git", ["rev-parse", "HEAD"], repositoryRoot)
-const shortRevision = revision.slice(0, 12)
-const temporaryDirectory = mkdtempSync(join(tmpdir(), "aml-agent-sandbox-release-"))
-const metadataPath = join(temporaryDirectory, "build-metadata.json")
-
-try {
-  run(
-    "docker",
-    [
-      "buildx",
-      "build",
-      "--platform",
-      "linux/amd64",
-      "--push",
-      "--sbom=true",
-      "--provenance=mode=max",
-      "--build-arg",
-      `IMAGE_VERSION=${version}`,
-      "--build-arg",
-      `VCS_REF=${revision}`,
-      "--tag",
-      `${dockerHubImage}:${version}`,
-      "--tag",
-      `${dockerHubImage}:sha-${shortRevision}`,
-      "--tag",
-      `${dockerHubImage}:latest`,
-      "--metadata-file",
-      metadataPath,
-      imageDirectory,
-    ],
-    repositoryRoot
-  )
-
-  const metadata = JSON.parse(readFileSync(metadataPath, "utf8"))
-  const digest = metadata["containerimage.digest"]
-  if (!/^sha256:[0-9a-f]{64}$/.test(digest ?? "")) {
-    throw new Error("Docker Buildx did not report a valid image digest")
+function main() {
+  if (version === "--check") {
+    requireCommand("docker", ["buildx", "version"])
+    requireCommand("cosign", ["version"])
+    verifyAttestationBuilder()
+    process.stdout.write("Docker image publishing tools and attestation builder are available\n")
+    return
   }
 
-  verifyDigest(`${dockerHubImage}:${version}`, digest)
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version ?? "")) {
+    throw new Error("Expected a semantic version argument")
+  }
 
-  run("cosign", ["sign", "--yes", `${dockerHubImage}@${digest}`], repositoryRoot)
+  const packageVersion = JSON.parse(readFileSync(join(imageDirectory, "package.json"), "utf8")).version
+  if (packageVersion !== version) {
+    throw new Error(`Release version ${version} does not match package version ${packageVersion}`)
+  }
 
-  process.stdout.write(`Published AML Agent Sandbox ${version}\nDigest: ${digest}\n`)
-} finally {
-  rmSync(temporaryDirectory, { recursive: true, force: true })
+  const revision = output("git", ["rev-parse", "HEAD"], repositoryRoot)
+  const shortRevision = revision.slice(0, 12)
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "aml-agent-sandbox-release-"))
+  const metadataPath = join(temporaryDirectory, "build-metadata.json")
+
+  try {
+    run(
+      "docker",
+      [
+        "buildx",
+        "build",
+        "--platform",
+        "linux/amd64",
+        "--push",
+        "--sbom=true",
+        "--provenance=mode=max",
+        "--build-arg",
+        `IMAGE_VERSION=${version}`,
+        "--build-arg",
+        `VCS_REF=${revision}`,
+        "--tag",
+        `${dockerHubImage}:${version}`,
+        "--tag",
+        `${dockerHubImage}:sha-${shortRevision}`,
+        "--tag",
+        `${dockerHubImage}:latest`,
+        "--metadata-file",
+        metadataPath,
+        imageDirectory,
+      ],
+      repositoryRoot
+    )
+
+    const metadata = JSON.parse(readFileSync(metadataPath, "utf8"))
+    const digest = metadata["containerimage.digest"]
+    if (!/^sha256:[0-9a-f]{64}$/.test(digest ?? "")) {
+      throw new Error("Docker Buildx did not report a valid image digest")
+    }
+
+    verifyDigest(`${dockerHubImage}:${version}`, digest)
+
+    run("cosign", ["sign", "--yes", `${dockerHubImage}@${digest}`], repositoryRoot)
+
+    process.stdout.write(`Published AML Agent Sandbox ${version}\nDigest: ${digest}\n`)
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true })
+  }
 }
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) main()
 
 function verifyDigest(reference, expectedDigest) {
   const digest = output(
@@ -93,6 +98,56 @@ function requireCommand(command, args) {
   if (result.status !== 0) {
     throw new Error(`${command} is installed but unavailable`)
   }
+}
+
+function verifyAttestationBuilder() {
+  const inspection = output("docker", ["buildx", "inspect", "--bootstrap"], repositoryRoot)
+  const builder = parseBuilderInspection(inspection)
+  const dockerInfo =
+    builder.driver === "docker"
+      ? JSON.parse(output("docker", ["info", "--format", "{{json .}}"], repositoryRoot))
+      : undefined
+  assertBuilderSupportsAttestations(builder, dockerInfo)
+}
+
+export function parseBuilderInspection(inspection) {
+  const name = /^Name:\s+(.+)$/m.exec(inspection)?.[1]?.trim()
+  const driver = /^Driver:\s+(.+)$/m.exec(inspection)?.[1]?.trim()
+  const buildkitVersions = [...inspection.matchAll(/^BuildKit version:\s+v?([^\s]+)$/gm)].map(match => match[1])
+
+  if (name === undefined || driver === undefined) {
+    throw new Error("Could not determine the current Buildx builder name and driver from docker buildx inspect")
+  }
+  if (buildkitVersions.length === 0) {
+    throw new Error(`Could not determine BuildKit version for Buildx builder ${name}`)
+  }
+
+  return { buildkitVersions, driver, name }
+}
+
+export function usesContainerdImageStore(dockerInfo) {
+  return dockerInfo.DriverStatus?.some(
+    status => Array.isArray(status) && status[0] === "driver-type" && status[1] === "io.containerd.snapshotter.v1"
+  )
+}
+
+export function assertBuilderSupportsAttestations(builder, dockerInfo) {
+  if (!builder.buildkitVersions.every(supportsBuildAttestations)) {
+    throw new Error(
+      `Buildx builder ${builder.name} uses BuildKit ${builder.buildkitVersions.join(", ") || "of unknown version"}; SBOM and provenance require BuildKit 0.11 or newer`
+    )
+  }
+
+  if (builder.driver !== "docker" || usesContainerdImageStore(dockerInfo ?? {})) return
+
+  throw new Error(
+    `Buildx builder ${builder.name} uses the docker driver with the classic image store, which cannot publish SBOM and provenance attestations. Select an existing docker-container builder with "docker buildx use <name>" (or BUILDX_BUILDER=<name> npm run release:docker), or enable Docker's containerd image store, then retry. The release script does not create or switch builders.`
+  )
+}
+
+function supportsBuildAttestations(version) {
+  const [major, minor] = version.split(".").map(value => Number.parseInt(value, 10))
+  return Number.isInteger(major) && Number.isInteger(minor) && (major > 0 || minor >= 11)
 }
 
 function output(command, args, cwd) {

--- a/images/aml-agent-sandbox/scripts/release.mjs
+++ b/images/aml-agent-sandbox/scripts/release.mjs
@@ -1,46 +1,53 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { homedir, tmpdir } from "node:os"
+import { join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import process from "node:process"
-import { URL } from "node:url"
+import { pathToFileURL, URL } from "node:url"
 
 const releaseArguments = process.argv.slice(2)
 const skipsPublishing = releaseArguments.some(argument => ["--dry-run", "--help", "--version"].includes(argument))
 const recoversRelease = releaseArguments.includes("--recover")
 
-try {
-  if (recoversRelease && releaseArguments.length !== 1) {
-    throw new Error(`--recover cannot be combined with other release arguments`)
-  }
-
-  if (skipsPublishing) {
-    const previewEnvironment = { ...process.env }
-    if (releaseArguments.includes("--dry-run")) {
-      previewEnvironment.GITHUB_TOKEN = output("gh", ["auth", "token"], process.env)
+export function main() {
+  try {
+    if (recoversRelease && releaseArguments.length !== 1) {
+      throw new Error(`--recover cannot be combined with other release arguments`)
     }
-    process.exitCode = run("release-it", releaseArguments, previewEnvironment)
-  } else {
-    process.exitCode = release()
+
+    if (skipsPublishing) {
+      const previewEnvironment = { ...process.env }
+      if (releaseArguments.includes("--dry-run")) {
+        previewEnvironment.GITHUB_TOKEN = output("gh", ["auth", "token"], process.env)
+      }
+      process.exitCode = run("release-it", releaseArguments, previewEnvironment)
+    } else {
+      process.exitCode = release()
+    }
+  } catch (error) {
+    process.stderr.write(`Release failed: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
   }
-} catch (error) {
-  process.stderr.write(`Release failed: ${error instanceof Error ? error.message : String(error)}\n`)
-  process.exitCode = 1
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main()
 }
 
 function release() {
   const recoveryVersion = recoversRelease ? readRecoveryVersion() : undefined
 
-  // Release It uses the active CLI token for the source tag's GitHub Release.
-  // Stable image publication itself authenticates only with Docker Hub.
-  const githubToken = output("gh", ["auth", "token"], process.env)
-
-  // Each release gets isolated registry credentials. This avoids mutating the
-  // Docker Desktop vault and guarantees that cleanup removes the release tokens.
-  const dockerConfig = mkdtempSync(join(tmpdir(), "aml-agent-sandbox-auth-"))
-  const releaseEnvironment = { ...process.env, DOCKER_CONFIG: dockerConfig, GITHUB_TOKEN: githubToken }
+  // Fail before Docker authentication or Release It can create a commit/tag.
+  // The check uses the caller's Buildx state assembled below.
+  const releaseEnvironment = createReleaseEnvironment(process.env)
+  const dockerConfig = releaseEnvironment.DOCKER_CONFIG
 
   try {
+    runOrThrow("node", ["scripts/publish.mjs", "--check"], releaseEnvironment)
+
+    // Release It uses the active CLI token for the source tag's GitHub Release.
+    // Stable image publication itself authenticates only with Docker Hub.
+    releaseEnvironment.GITHUB_TOKEN = output("gh", ["auth", "token"], process.env)
     runOrThrow("docker", ["login"], releaseEnvironment)
 
     if (recoveryVersion) {
@@ -53,6 +60,21 @@ function release() {
     return run("release-it", releaseArguments, releaseEnvironment)
   } finally {
     rmSync(dockerConfig, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Isolates registry credentials while retaining the caller's named builders,
+ * current-builder selection, BuildKit configuration, and build history.
+ */
+export function createReleaseEnvironment(environment, createTemporaryDirectory = mkdtempSync) {
+  const callerDockerConfig = environment.DOCKER_CONFIG ?? join(homedir(), ".docker")
+  const dockerConfig = createTemporaryDirectory(join(tmpdir(), "aml-agent-sandbox-auth-"))
+
+  return {
+    ...environment,
+    BUILDX_CONFIG: environment.BUILDX_CONFIG ?? join(callerDockerConfig, "buildx"),
+    DOCKER_CONFIG: dockerConfig,
   }
 }
 

--- a/images/aml-agent-sandbox/scripts/release.test.mjs
+++ b/images/aml-agent-sandbox/scripts/release.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { assertBuilderSupportsAttestations, parseBuilderInspection, usesContainerdImageStore } from "./publish.mjs"
+import { createReleaseEnvironment } from "./release.mjs"
+
+test("isolates Docker credentials while preserving caller Buildx state", () => {
+  const environment = createReleaseEnvironment(
+    { DOCKER_CONFIG: "/caller/docker", BUILDX_BUILDER: "publisher" },
+    prefix => `${prefix}temporary`
+  )
+
+  assert.equal(environment.DOCKER_CONFIG.endsWith("temporary"), true)
+  assert.equal(environment.BUILDX_CONFIG, "/caller/docker/buildx")
+  assert.equal(environment.BUILDX_BUILDER, "publisher")
+})
+
+test("preserves an explicit Buildx configuration directory", () => {
+  const environment = createReleaseEnvironment({ BUILDX_CONFIG: "/caller/buildx" }, prefix => `${prefix}temporary`)
+
+  assert.equal(environment.BUILDX_CONFIG, "/caller/buildx")
+})
+
+test("reads the current builder driver and every BuildKit node version", () => {
+  assert.deepEqual(
+    parseBuilderInspection(
+      `Name: publisher\nDriver: docker-container\nBuildKit version: v0.12.5\nBuildKit version: v0.13.2\n`
+    ),
+    {
+      buildkitVersions: ["0.12.5", "0.13.2"],
+      driver: "docker-container",
+      name: "publisher",
+    }
+  )
+})
+
+test("recognizes Docker's documented containerd image-store marker", () => {
+  assert.equal(usesContainerdImageStore({ DriverStatus: [["driver-type", "io.containerd.snapshotter.v1"]] }), true)
+  assert.equal(usesContainerdImageStore({ DriverStatus: [["Backing Filesystem", "extfs"]] }), false)
+})
+
+test("rejects the Docker classic image store with actionable alternatives", () => {
+  assert.throws(
+    () =>
+      assertBuilderSupportsAttestations(
+        { buildkitVersions: ["0.30.0"], driver: "docker", name: "default" },
+        { DriverStatus: [["Backing Filesystem", "extfs"]] }
+      ),
+    /Select an existing docker-container builder.*or enable Docker's containerd image store/
+  )
+})
+
+test("accepts a current docker-container builder", () => {
+  assert.doesNotThrow(() =>
+    assertBuilderSupportsAttestations({
+      buildkitVersions: ["0.32.2"],
+      driver: "docker-container",
+      name: "publisher",
+    })
+  )
+})

--- a/images/aml-agent-sandbox/scripts/verify-release.mjs
+++ b/images/aml-agent-sandbox/scripts/verify-release.mjs
@@ -1,0 +1,92 @@
+import { spawnSync } from "node:child_process"
+import process from "node:process"
+
+const dockerHubImage = "docker.io/wearesingular/aml-agent-sandbox"
+const [version, digest, ...policyArguments] = process.argv.slice(2)
+
+if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version ?? "")) {
+  throw new Error("Expected a semantic version as the first argument")
+}
+if (!/^sha256:[0-9a-f]{64}$/.test(digest ?? "")) {
+  throw new Error("Expected an immutable sha256 digest as the second argument")
+}
+
+const policy = parsePolicy(policyArguments)
+const tag = `docker-v${version}`
+const revision = output("git", ["rev-list", "-n", "1", tag])
+if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error(`Could not resolve source revision for ${tag}`)
+
+const references = [
+  `${dockerHubImage}:${version}`,
+  `${dockerHubImage}:sha-${revision.slice(0, 12)}`,
+  `${dockerHubImage}:latest`,
+]
+
+for (const reference of references) verifyDigest(reference, digest)
+const immutableReference = `${dockerHubImage}@${digest}`
+
+run("cosign", [
+  "verify",
+  "--certificate-identity",
+  policy.identity,
+  "--certificate-oidc-issuer",
+  policy.issuer,
+  immutableReference,
+])
+
+verifyAttestation("SBOM", "{{if .SBOM}}present{{else}}missing{{end}}", immutableReference)
+verifyAttestation("provenance", "{{if .Provenance}}present{{else}}missing{{end}}", immutableReference)
+
+const release = JSON.parse(output("gh", ["release", "view", tag, "--json", "tagName,isDraft,isPrerelease,url"]))
+if (release.tagName !== tag || release.isDraft || release.isPrerelease) {
+  throw new Error(`GitHub Release ${tag} is missing or is not a final release`)
+}
+
+process.stdout.write(
+  `Verified AML Agent Sandbox ${version}\nDigest: ${digest}\nTags: ${references.join(", ")}\nGitHub Release: ${release.url}\n`
+)
+
+function parsePolicy(args) {
+  let identity
+  let issuer
+
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index]
+    const value = args[index + 1]
+    if (value === undefined) throw new Error(`${flag} requires a value`)
+    if (flag === "--certificate-identity") identity = value
+    else if (flag === "--certificate-oidc-issuer") issuer = value
+    else throw new Error(`Unknown verification option ${flag}`)
+  }
+
+  if (identity === undefined || issuer === undefined) {
+    throw new Error("Verification requires exact --certificate-identity and --certificate-oidc-issuer values")
+  }
+  return { identity, issuer }
+}
+
+function verifyDigest(reference, expectedDigest) {
+  const resolved = output("docker", ["buildx", "imagetools", "inspect", reference, "--format", "{{.Manifest.Digest}}"])
+  if (resolved !== expectedDigest) throw new Error(`${reference} resolved to ${resolved}, expected ${expectedDigest}`)
+}
+
+function verifyAttestation(name, format, reference) {
+  const value = output("docker", ["buildx", "imagetools", "inspect", reference, "--format", format])
+  if (value !== "present") throw new Error(`${reference} has no ${name} attestation`)
+}
+
+function output(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8" })
+  if (result.error?.code === "ENOENT") throw new Error(`${command} is required to verify the release`)
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr)
+    throw new Error(`${command} exited with status ${result.status}`)
+  }
+  return result.stdout.trim()
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" })
+  if (result.error?.code === "ENOENT") throw new Error(`${command} is required to verify the release`)
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status}`)
+}

--- a/sdk/tests/smoke-runner.test.ts
+++ b/sdk/tests/smoke-runner.test.ts
@@ -7,6 +7,7 @@ import {
   parseKitchenSinkCommand,
   parseSmokeCommand,
   requiredCopilotGithubToken,
+  resolveSmokeSandboxImage,
   selectSmokeCases,
   SMOKE_AGENT_NAMES,
   SMOKE_SANDBOX_NAMES,
@@ -28,6 +29,12 @@ describe("smoke configuration", () => {
     expect(selectSmokeCases({ sandbox: "docker" })).toEqual(
       SMOKE_AGENT_NAMES.map(agent => ({ agent, sandbox: "docker" }))
     )
+  })
+
+  it("pins one requested image across image-backed smoke Sandboxes", () => {
+    const image = "docker.io/wearesingular/aml-agent-sandbox@sha256:example"
+    expect(resolveSmokeSandboxImage({ AML_SMOKE_SANDBOX_IMAGE: image })).toBe(image)
+    expect(resolveSmokeSandboxImage({})).toBe("ghcr.io/we-are-singular/aml-agent-sandbox:dev")
   })
 
   it("parses CLI filters", () => {

--- a/sdk/tests/smoke/smoke-config.ts
+++ b/sdk/tests/smoke/smoke-config.ts
@@ -24,7 +24,7 @@ export function loadSmokeEnvironment(): void {
 }
 
 const SMOKE_AGENT_PATH = `/tmp/aml-agents/bin:/opt/aml-agent-sandbox/node_modules/.bin:${process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin"}`
-const SMOKE_SANDBOX_IMAGE = "ghcr.io/we-are-singular/aml-agent-sandbox:dev"
+const DEFAULT_SMOKE_SANDBOX_IMAGE = "ghcr.io/we-are-singular/aml-agent-sandbox:dev"
 const ALL_AGENTS_PRESENT =
   "test -f input.txt && command -v codex-acp && command -v codex && command -v copilot && command -v glm-acp-agent && command -v opencode && command -v pi-acp && command -v pi && command -v pi-mcp-adapter"
 
@@ -126,15 +126,17 @@ export const SMOKE_SANDBOXES = {
       if (apiKey === undefined) throw new Error("Daytona smoke requires DAYTONA_API_KEY")
       return daytonaSandbox({
         config: { apiKey },
-        image: SMOKE_SANDBOX_IMAGE,
+        image: resolveSmokeSandboxImage(),
       })
     },
-    environment: SMOKE_SANDBOX_IMAGE,
+    get environment() {
+      return resolveSmokeSandboxImage()
+    },
   },
   docker: {
     create() {
       return dockerSandbox({
-        image: SMOKE_SANDBOX_IMAGE,
+        image: resolveSmokeSandboxImage(),
         // Match the owner of the bind-mounted local Workspace while keeping
         // the container and its coding Agents unprivileged.
         ...(typeof process.getuid === "function" && typeof process.getgid === "function"
@@ -142,7 +144,9 @@ export const SMOKE_SANDBOXES = {
           : {}),
       })
     },
-    environment: SMOKE_SANDBOX_IMAGE,
+    get environment() {
+      return resolveSmokeSandboxImage()
+    },
   },
   local: {
     create() {
@@ -161,14 +165,21 @@ export const SMOKE_SANDBOXES = {
         appName: "aml-jsx-smoke",
         config: { tokenId, tokenSecret },
         create: { memoryMiB: 2_048, timeoutMs: 300_000 },
-        image: SMOKE_SANDBOX_IMAGE,
+        image: resolveSmokeSandboxImage(),
       })
     },
-    environment: SMOKE_SANDBOX_IMAGE,
+    get environment() {
+      return resolveSmokeSandboxImage()
+    },
   },
 } satisfies Record<string, SmokeSandboxRegistration>
 
 export type SmokeSandboxName = keyof typeof SMOKE_SANDBOXES
+
+/** Uses one explicit image reference for every image-backed smoke Sandbox. */
+export function resolveSmokeSandboxImage(environment: Readonly<NodeJS.ProcessEnv> = process.env): string {
+  return environment.AML_SMOKE_SANDBOX_IMAGE ?? DEFAULT_SMOKE_SANDBOX_IMAGE
+}
 
 export const KITCHEN_SINK_WORKSPACE_NAMES = ["local", "r2"] as const
 export const KITCHEN_SINK_MCP_NAMES = ["context7", "none"] as const


### PR DESCRIPTION
## Description

Repairs the local stable image release workflow based on evidence from the 0.1.0 release, and adds a literal post-publication verification path.

## What changed?

- Preserves the caller Buildx configuration and selected builder while keeping Docker Hub credentials temporary.
- Fails before release commits or tags when the selected builder cannot publish SBOM and provenance attestations.
- Adds exact digest, tag, Cosign policy, attestation, and GitHub Release verification.
- Documents browser authentication without assuming WSL or a specific browser path.
- Allows Docker, Daytona, and Modal smoke cells to share one explicit immutable image reference.
- Adds focused coverage for release environment handling, builder capability checks, and smoke image selection.

## Verification

- Confirmed the preflight rejects the classic Docker image store and accepts the existing Docker-container publishing builder.
- Independently pulled and verified the published 0.1.0 digest, conformance probe, exact Cosign identity and issuer, SBOM, provenance, stable tags, and GitHub Release.
- Ran all 15 image-backed Agent/provider cells against the immutable 0.1.0 digest; 14 passed, with the known Copilot × Daytona pair remaining the only failure.
- Confirmed deterministic cancellation coverage and cleanup behavior remain green.

> Builders keep their names
> Signed digests anchor each run
> Stable smoke holds fast