### PR TITLE
feat(providers): accept any reasoning effort string

### DIFF
--- a/apps/website/src/content/docs/docs/providers/agents/codex.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/codex.mdx
@@ -116,17 +116,19 @@ If you use the repository's live ACP test pattern, the adapter can be launched t
 
 ## Options and precedence
 
-| Option              | Type                                                  | Default       | Semantics                                                                                  |
-| ------------------- | ----------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------ |
-| `apiKey`            | `string`                                              | —             | Adds `CODEX_API_KEY` and selects the ACP `api-key` authentication method.                  |
-| `command`           | `string`                                              | `"codex-acp"` | ACP executable or launcher. It must be a non-empty, trimmed string without null bytes.     |
-| `args`              | `readonly string[]`                                   | `[]`          | Appended to the launch command exactly as supplied. Arguments cannot contain null bytes.   |
-| `config`            | JSON-compatible object                                | `{}`          | Base Codex configuration. It must serialize successfully before any external work begins.  |
-| `codexPathOverride` | `string`                                              | `"codex"`     | Sets `CODEX_PATH` for the ACP adapter; it does not replace `command`.                      |
-| `env`               | `Record<string, string>`                              | `{}`          | Additional launch environment. Use it for provider-specific credentials and configuration. |
-| `model`             | `string`                                              | —             | Provider-level model fallback.                                                             |
-| `reasoningEffort`   | `"minimal" \| "low" \| "medium" \| "high" \| "xhigh"` | —             | Writes `model_reasoning_effort` into Codex configuration.                                  |
-| `workingDirectory`  | `string`                                              | —             | Fallback working directory when no Sandbox supplies the effective directory.               |
+| Option              | Type                     | Default       | Semantics                                                                                  |
+| ------------------- | ------------------------ | ------------- | ------------------------------------------------------------------------------------------ |
+| `apiKey`            | `string`                 | —             | Adds `CODEX_API_KEY` and selects the ACP `api-key` authentication method.                  |
+| `command`           | `string`                 | `"codex-acp"` | ACP executable or launcher. It must be a non-empty, trimmed string without null bytes.     |
+| `args`              | `readonly string[]`      | `[]`          | Appended to the launch command exactly as supplied. Arguments cannot contain null bytes.   |
+| `config`            | JSON-compatible object   | `{}`          | Base Codex configuration. It must serialize successfully before any external work begins.  |
+| `codexPathOverride` | `string`                 | `"codex"`     | Sets `CODEX_PATH` for the ACP adapter; it does not replace `command`.                      |
+| `env`               | `Record<string, string>` | `{}`          | Additional launch environment. Use it for provider-specific credentials and configuration. |
+| `model`             | `string`                 | —             | Provider-level model fallback.                                                             |
+| `reasoningEffort`   | `string`                 | —             | Writes the provider-native value into `model_reasoning_effort` in Codex configuration.     |
+| `workingDirectory`  | `string`                 | —             | Fallback working directory when no Sandbox supplies the effective directory.               |
+
+Values such as `"high"` in the examples are provider-native examples, not an AML allowlist. AML only checks that the value is a normalized non-empty string without null bytes, then forwards it to Codex unchanged.
 
 The effective values are resolved as follows:
 

--- a/apps/website/src/content/docs/docs/providers/agents/copilot.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/copilot.mdx
@@ -129,14 +129,16 @@ or repository file.
 
 ## Options and precedence
 
-| Option             | Type                                                                     | Default     | Semantics                                                                                  |
-| ------------------ | ------------------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
-| `command`          | `string`                                                                 | `"copilot"` | Copilot ACP executable or application-owned launcher.                                      |
-| `args`             | `readonly string[]`                                                      | `[]`        | Extra Copilot arguments inserted before AML-owned ACP, isolation, model, and policy flags. |
-| `env`              | `Record<string, string>`                                                 | `{}`        | Optional runtime environment overlay; AML does not filter or rewrite credential variables. |
-| `model`            | `string`                                                                 | `"auto"`    | Provider-level model fallback.                                                             |
-| `reasoningEffort`  | `"none" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "max"` | —           | Copilot reasoning-effort flag; the chosen model and plan must support it.                  |
-| `workingDirectory` | `string`                                                                 | —           | Fallback cwd when no active Sandbox supplies one.                                          |
+| Option             | Type                     | Default     | Semantics                                                                                  |
+| ------------------ | ------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
+| `command`          | `string`                 | `"copilot"` | Copilot ACP executable or application-owned launcher.                                      |
+| `args`             | `readonly string[]`      | `[]`        | Extra Copilot arguments inserted before AML-owned ACP, isolation, model, and policy flags. |
+| `env`              | `Record<string, string>` | `{}`        | Optional runtime environment overlay; AML does not filter or rewrite credential variables. |
+| `model`            | `string`                 | `"auto"`    | Provider-level model fallback.                                                             |
+| `reasoningEffort`  | `string`                 | —           | Provider-native value passed through as Copilot's reasoning-effort flag.                   |
+| `workingDirectory` | `string`                 | —           | Fallback cwd when no active Sandbox supplies one.                                          |
+
+Values such as `"low"` in the examples are provider-native examples, not an AML allowlist. AML only checks that the value is a normalized non-empty string without null bytes, then forwards it to Copilot unchanged.
 
 Precedence is deliberate:
 

--- a/apps/website/src/content/docs/docs/providers/agents/pi.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/pi.mdx
@@ -160,16 +160,18 @@ The wrapper adds `mcp` to Pi's allowed tool list and writes an `agent/mcp.json` 
 
 ## Options and precedence
 
-| Option             | Type                                                                    | Default                       | Semantics                                                         |
-| ------------------ | ----------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------- |
-| `command`          | `string`                                                                | `"pi-acp"`                    | Outer ACP executable.                                             |
-| `args`             | `readonly string[]`                                                     | `[]`                          | Extra ACP arguments, passed exactly as supplied.                  |
-| `env`              | `Record<string, string>`                                                | `{}`                          | Provider credentials and native environment configuration.        |
-| `mcpAdapterPath`   | `string`                                                                | auto-discovered when possible | Path to the installed `pi-mcp-adapter` entrypoint.                |
-| `model`            | `string`                                                                | —                             | Provider-level model fallback. `<Agent model="..." />` wins.      |
-| `piCommand`        | `string`                                                                | `"pi"`                        | Native Pi command used by the direct or generated wrapper launch. |
-| `thinkingLevel`    | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "max"` | —                             | Adds Pi's `thought_level` configuration value.                    |
-| `workingDirectory` | `string`                                                                | —                             | Fallback directory when no Sandbox supplies the effective cwd.    |
+| Option             | Type                     | Default                       | Semantics                                                             |
+| ------------------ | ------------------------ | ----------------------------- | --------------------------------------------------------------------- |
+| `command`          | `string`                 | `"pi-acp"`                    | Outer ACP executable.                                                 |
+| `args`             | `readonly string[]`      | `[]`                          | Extra ACP arguments, passed exactly as supplied.                      |
+| `env`              | `Record<string, string>` | `{}`                          | Provider credentials and native environment configuration.            |
+| `mcpAdapterPath`   | `string`                 | auto-discovered when possible | Path to the installed `pi-mcp-adapter` entrypoint.                    |
+| `model`            | `string`                 | —                             | Provider-level model fallback. `<Agent model="..." />` wins.          |
+| `piCommand`        | `string`                 | `"pi"`                        | Native Pi command used by the direct or generated wrapper launch.     |
+| `thinkingLevel`    | `string`                 | —                             | Adds the provider-native value as Pi's `thought_level` configuration. |
+| `workingDirectory` | `string`                 | —                             | Fallback directory when no Sandbox supplies the effective cwd.        |
+
+Values such as `"medium"` in the examples are provider-native examples, not an AML allowlist. AML only checks that the value is a normalized non-empty string without null bytes, then forwards it to Pi ACP unchanged; the adapter must advertise the selected value through ACP.
 
 Precedence and launch behavior:
 
@@ -269,7 +271,7 @@ AML materializes wrapper files, Pi settings, and lazy MCP configuration into tha
 
 6. **Configuration fails before launch**
 
-   Commands, paths, model names, and args must be normalized strings. `thinkingLevel` must be one of the documented values, and args cannot contain null bytes.
+   Commands, paths, model names, and `thinkingLevel` must be normalized strings, and args cannot contain null bytes. Pi ACP must advertise the selected `thought_level` value.
 
 </Steps>
 

--- a/providers/agents/codex/src/codex-agent.ts
+++ b/providers/agents/codex/src/codex-agent.ts
@@ -15,10 +15,6 @@ export type CodexConfigValue =
   | readonly CodexConfigValue[]
   | Readonly<{ readonly [key: string]: CodexConfigValue }>
 
-export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh"
-
-const REASONING_EFFORTS = new Set<CodexReasoningEffort>(["minimal", "low", "medium", "high", "xhigh"])
-
 export interface CodexAgentOptions {
   readonly apiKey?: string
   readonly args?: readonly string[]
@@ -27,7 +23,7 @@ export interface CodexAgentOptions {
   readonly config?: Readonly<Record<string, CodexConfigValue>>
   readonly env?: Readonly<Record<string, string>>
   readonly model?: string
-  readonly reasoningEffort?: CodexReasoningEffort
+  readonly reasoningEffort?: string
   readonly workingDirectory?: string
 }
 
@@ -43,7 +39,7 @@ interface CapturedCodexAgentOptions {
   readonly config: Readonly<Record<string, CodexConfigValue>>
   readonly env: Readonly<Record<string, string>>
   readonly model?: string
-  readonly reasoningEffort?: CodexReasoningEffort
+  readonly reasoningEffort?: string
   readonly workingDirectory?: string
 }
 
@@ -117,7 +113,7 @@ function captureOptions(value: CodexAgentOptions): Readonly<CapturedCodexAgentOp
   const config = value.config ?? {}
   const codexPathOverride = optionalNormalizedString(value.codexPathOverride, "Codex codexPathOverride")
   const model = optionalNormalizedString(value.model, "Codex model")
-  const reasoningEffort = value.reasoningEffort
+  const reasoningEffort = optionalNormalizedString(value.reasoningEffort, "Codex reasoningEffort")
 
   if (!Array.isArray(args) || args.some(argument => typeof argument !== "string" || argument.includes("\0"))) {
     throw new TypeError("Codex args must be strings without null bytes")
@@ -133,10 +129,6 @@ function captureOptions(value: CodexAgentOptions): Readonly<CapturedCodexAgentOp
 
   // Validate serialization before Sandbox acquisition performs external work.
   stringifyConfig(config)
-
-  if (reasoningEffort !== undefined && !REASONING_EFFORTS.has(reasoningEffort)) {
-    throw new TypeError("Codex reasoningEffort is unsupported")
-  }
 
   return Object.freeze({
     ...(value.apiKey === undefined ? {} : { apiKey: normalizedString(value.apiKey, "Codex apiKey") }),

--- a/providers/agents/codex/src/index.ts
+++ b/providers/agents/codex/src/index.ts
@@ -1,7 +1,1 @@
-export {
-  codexAgent,
-  type CodexAgentOptions,
-  type CodexAgentProvider,
-  type CodexConfigValue,
-  type CodexReasoningEffort,
-} from "./codex-agent.js"
+export { codexAgent, type CodexAgentOptions, type CodexAgentProvider, type CodexConfigValue } from "./codex-agent.js"

--- a/providers/agents/codex/tests/codex-agent.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.test.tsx
@@ -105,6 +105,27 @@ describe("codexAgent()", () => {
     expect(config).toMatchObject({ model: "provider-model" })
   })
 
+  it.each(["max", "ultra"])("passes arbitrary reasoning effort %s through CODEX_CONFIG", async reasoningEffort => {
+    let config: Record<string, unknown> | undefined
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn(_command, _args, _request, options) {
+        config = JSON.parse(options.env?.CODEX_CONFIG ?? "")
+        return completedProcess()
+      },
+    })
+
+    await expect(
+      new AmlRuntime({ agentProvider: codexAgent({ reasoningEffort }) }).evaluate(
+        <Sandbox provider={sandboxProvider}>
+          <Agent>Prompt</Agent>
+        </Sandbox>
+      )
+    ).rejects.toThrow()
+
+    expect(config).toMatchObject({ model_reasoning_effort: reasoningEffort })
+  })
+
   it("validates process configuration without external work", () => {
     expect(() => codexAgent({ command: " codex-acp " })).toThrow("command must be a non-empty normalized string")
   })

--- a/providers/agents/copilot/src/copilot-agent.ts
+++ b/providers/agents/copilot/src/copilot-agent.ts
@@ -6,10 +6,6 @@ import {
   type AgentProvider,
 } from "@aml-jsx/sdk"
 
-/** Reasoning levels accepted by GitHub Copilot CLI. */
-export type CopilotReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
-
-const REASONING_EFFORTS = new Set<CopilotReasoningEffort>(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 const AUTH_TOKEN_ENVIRONMENT_VARIABLES = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"] as const
 
 /** Configures GitHub Copilot CLI's native ACP server. */
@@ -18,7 +14,7 @@ export interface CopilotAgentOptions {
   readonly command?: string
   readonly env?: Readonly<Record<string, string>>
   readonly model?: string
-  readonly reasoningEffort?: CopilotReasoningEffort
+  readonly reasoningEffort?: string
   readonly workingDirectory?: string
 }
 
@@ -31,7 +27,7 @@ interface CapturedCopilotAgentOptions {
   readonly command: string
   readonly env: Readonly<Record<string, string>>
   readonly model: string
-  readonly reasoningEffort?: CopilotReasoningEffort
+  readonly reasoningEffort?: string
   readonly workingDirectory?: string
 }
 
@@ -161,7 +157,7 @@ function captureOptions(options: CopilotAgentOptions): Readonly<CapturedCopilotA
   const command = normalizedString(options.command ?? "copilot", "Copilot command")
   const env = options.env ?? {}
   const model = normalizedString(options.model ?? "auto", "Copilot model")
-  const reasoningEffort = options.reasoningEffort
+  const reasoningEffort = optionalNormalizedString(options.reasoningEffort, "Copilot reasoningEffort")
   const workingDirectory = optionalNormalizedString(options.workingDirectory, "Copilot workingDirectory")
 
   if (!Array.isArray(args) || args.some(argument => typeof argument !== "string" || argument.includes("\0"))) {
@@ -170,10 +166,6 @@ function captureOptions(options: CopilotAgentOptions): Readonly<CapturedCopilotA
 
   if (typeof env !== "object" || env === null || Array.isArray(env)) {
     throw new TypeError("Copilot env must be an object")
-  }
-
-  if (reasoningEffort !== undefined && !REASONING_EFFORTS.has(reasoningEffort)) {
-    throw new TypeError("Copilot reasoningEffort is unsupported")
   }
 
   return Object.freeze({

--- a/providers/agents/copilot/src/index.ts
+++ b/providers/agents/copilot/src/index.ts
@@ -1,6 +1,1 @@
-export {
-  copilotAgent,
-  type CopilotAgentOptions,
-  type CopilotAgentProvider,
-  type CopilotReasoningEffort,
-} from "./copilot-agent.js"
+export { copilotAgent, type CopilotAgentOptions, type CopilotAgentProvider } from "./copilot-agent.js"

--- a/providers/agents/copilot/tests/copilot-agent.test.tsx
+++ b/providers/agents/copilot/tests/copilot-agent.test.tsx
@@ -112,7 +112,7 @@ describe("copilotAgent()", () => {
     vi.stubEnv("GH_TOKEN", "ambient-gh-token")
     vi.stubEnv("GITHUB_TOKEN", "ambient-github-token")
 
-    const launchArgs = await captureLocalLaunchArgs({ GITHUB_TOKEN: "explicit-github-token" })
+    const launchArgs = await captureLocalLaunchArgs({ env: { GITHUB_TOKEN: "explicit-github-token" } })
 
     expect(launchArgs).toContain("--auth-token-env=GITHUB_TOKEN")
   })
@@ -178,17 +178,23 @@ describe("copilotAgent()", () => {
     expect(prompt).toContain(`Call the Copilot MCP tool "${mcpServerName}-aml_submit_result" once`)
   })
 
-  it("validates options before launch", () => {
+  it("validates options before launch and forwards arbitrary reasoning effort", async () => {
     expect(() => copilotAgent({ command: " copilot " })).toThrow(
       "Copilot command must be a non-empty normalized string"
     )
-    expect(() => copilotAgent({ reasoningEffort: "impossible" as "low" })).toThrow(
-      "Copilot reasoningEffort is unsupported"
-    )
+
+    const launchArgs = await captureLocalLaunchArgs({ reasoningEffort: "impossible" })
+
+    expect(launchArgs).toContain("--reasoning-effort=impossible")
   })
 })
 
-async function captureLocalLaunchArgs(env?: Readonly<Record<string, string>>): Promise<readonly string[]> {
+async function captureLocalLaunchArgs(
+  options: {
+    readonly env?: Readonly<Record<string, string>>
+    readonly reasoningEffort?: string
+  } = {}
+): Promise<readonly string[]> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "aml-copilot-launch-test-"))
   const outputFile = path.join(directory, "args.json")
   const captureScript =
@@ -200,7 +206,8 @@ async function captureLocalLaunchArgs(env?: Readonly<Record<string, string>>): P
         agentProvider: copilotAgent({
           args: ["--input-type=module", "-e", captureScript, outputFile],
           command: process.execPath,
-          ...(env === undefined ? {} : { env }),
+          ...(options.env === undefined ? {} : { env: options.env }),
+          ...(options.reasoningEffort === undefined ? {} : { reasoningEffort: options.reasoningEffort }),
         }),
       }).evaluate(<Agent>Prompt</Agent>)
     ).rejects.toThrow()

--- a/providers/agents/pi/src/index.ts
+++ b/providers/agents/pi/src/index.ts
@@ -1,1 +1,1 @@
-export { piAgent, type PiAgentOptions, type PiAgentProvider, type PiThinkingLevel } from "./pi-agent.js"
+export { piAgent, type PiAgentOptions, type PiAgentProvider } from "./pi-agent.js"

--- a/providers/agents/pi/src/pi-agent.ts
+++ b/providers/agents/pi/src/pi-agent.ts
@@ -6,10 +6,6 @@ import {
   type AgentProvider,
 } from "@aml-jsx/sdk"
 
-/** Reasoning levels exposed by the maintained Pi ACP adapter. */
-export type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
-const PI_THINKING_LEVELS = new Set<PiThinkingLevel>(["off", "minimal", "low", "medium", "high", "xhigh", "max"])
-
 /**
  * Configures the maintained pi-acp adapter and underlying Pi command.
  */
@@ -26,7 +22,7 @@ export interface PiAgentOptions {
   readonly mcpAdapterPath?: string
   readonly model?: string
   readonly piCommand?: string
-  readonly thinkingLevel?: PiThinkingLevel
+  readonly thinkingLevel?: string
   readonly workingDirectory?: string
 }
 
@@ -41,7 +37,7 @@ interface CapturedPiAgentOptions {
   readonly mcpAdapterPath?: string
   readonly model?: string
   readonly piCommand: string
-  readonly thinkingLevel?: PiThinkingLevel
+  readonly thinkingLevel?: string
   readonly workingDirectory?: string
 }
 
@@ -170,7 +166,7 @@ function captureOptions(options: PiAgentOptions): Readonly<CapturedPiAgentOption
   const mcpAdapterPath = optionalNormalizedString(options.mcpAdapterPath, "Pi MCP adapter path")
   const model = optionalNormalizedString(options.model, "Pi model")
   const piCommand = normalizedString(options.piCommand ?? "pi", "Pi command")
-  const thinkingLevel = options.thinkingLevel
+  const thinkingLevel = optionalNormalizedString(options.thinkingLevel, "Pi thinkingLevel")
   const workingDirectory = optionalNormalizedString(options.workingDirectory, "Pi workingDirectory")
 
   if (!Array.isArray(args) || args.some(argument => typeof argument !== "string" || argument.includes("\0"))) {
@@ -179,10 +175,6 @@ function captureOptions(options: PiAgentOptions): Readonly<CapturedPiAgentOption
 
   if (typeof env !== "object" || env === null || Array.isArray(env)) {
     throw new TypeError("Pi env must be an object")
-  }
-
-  if (thinkingLevel !== undefined && !PI_THINKING_LEVELS.has(thinkingLevel)) {
-    throw new TypeError("Pi thinkingLevel is unsupported")
   }
 
   return Object.freeze({

--- a/providers/agents/pi/tests/pi-agent.test.tsx
+++ b/providers/agents/pi/tests/pi-agent.test.tsx
@@ -8,6 +8,7 @@ import { piAgent } from "../src/index.js"
 describe("piAgent()", () => {
   it("launches pi-acp and configures the underlying Agent through ACP", async () => {
     const prompts: string[] = []
+    const configuredThinkingLevels: string[] = []
     const executed: Array<{
       readonly args: readonly string[]
       readonly command: string
@@ -29,7 +30,12 @@ describe("piAgent()", () => {
       },
       spawn(command, args, _request, options) {
         spawned.push({ args, command, options })
-        return acpFixtureProcess(prompt => prompts.push(prompt))
+        return acpFixtureProcess(prompt => prompts.push(prompt), {
+          onThinkingLevel(value) {
+            configuredThinkingLevels.push(value)
+          },
+          thinkingLevel: "ultra",
+        })
       },
     })
     const provider = piAgent({
@@ -38,7 +44,7 @@ describe("piAgent()", () => {
       env: { OPENCODE_API_KEY: "configured" },
       model: "opencode-go/minimax-m3",
       piCommand: "custom-pi",
-      thinkingLevel: "high",
+      thinkingLevel: "ultra",
     })
 
     await expect(
@@ -80,15 +86,18 @@ describe("piAgent()", () => {
       },
     })
     expect(prompts).toEqual(["<SYSTEM>\nFollow the system.\n</SYSTEM>\n\nInitial"])
+    expect(configuredThinkingLevels).toEqual(["ultra"])
   })
 
   it("validates adapter configuration without external work", () => {
     expect(() => piAgent({ command: " pi-acp " })).toThrow("Pi ACP command must be a non-empty normalized string")
-    expect(() => piAgent({ thinkingLevel: "impossible" as "high" })).toThrow("Pi thinkingLevel is unsupported")
   })
 })
 
-function acpFixtureProcess(onPrompt: (prompt: string) => void): Readonly<SandboxProcess> {
+function acpFixtureProcess(
+  onPrompt: (prompt: string) => void,
+  options: { readonly onThinkingLevel?: (value: string) => void; readonly thinkingLevel?: string } = {}
+): Readonly<SandboxProcess> {
   const clientToAgent = new TransformStream<Uint8Array, Uint8Array>()
   const agentToClient = new TransformStream<Uint8Array, Uint8Array>()
   const configOptions: SessionConfigOption[] = [
@@ -102,10 +111,10 @@ function acpFixtureProcess(onPrompt: (prompt: string) => void): Readonly<Sandbox
     },
     {
       category: "thought_level",
-      currentValue: "high",
+      currentValue: options.thinkingLevel ?? "high",
       id: "thinking-level",
       name: "Thinking level",
-      options: [{ name: "High", value: "high" }],
+      options: [{ name: options.thinkingLevel ?? "high", value: options.thinkingLevel ?? "high" }],
       type: "select",
     },
   ]
@@ -115,7 +124,12 @@ function acpFixtureProcess(onPrompt: (prompt: string) => void): Readonly<Sandbox
       protocolVersion: params.protocolVersion,
     }))
     .onRequest(methods.agent.session.new, () => ({ configOptions, sessionId: "pi-test-session" }))
-    .onRequest(methods.agent.session.setConfigOption, () => ({ configOptions }))
+    .onRequest(methods.agent.session.setConfigOption, ({ params }) => {
+      if (params.configId === "thinking-level" && typeof params.value === "string") {
+        options.onThinkingLevel?.(params.value)
+      }
+      return { configOptions }
+    })
     .onRequest(methods.agent.session.prompt, ({ params }) => {
       onPrompt(params.prompt.flatMap(block => (block.type === "text" ? [block.text] : [])).join(""))
       return { stopReason: "end_turn" }


### PR DESCRIPTION
closes #15

## What changed

- Widened Codex, Copilot, and Pi reasoning/thinking options to plain strings.
- Removed AML-owned unions, sets, and unsupported-value guards.
- Added pass-through coverage for Codex `max`/`ultra`, Copilot `impossible`, and Pi `ultra`.
- Updated provider docs to label recommended values as examples and explain that AML forwards strings without vocabulary validation.

## Validation

- Codex, Copilot, and Pi focused test suites passed, with only their existing integration skips.
- Codex, Copilot, and Pi lint/typecheck suites passed.
- SDK lint, targeted formatting checks, and `git diff --check` passed.

> Provider vocabularies change
> AML forwards each string
> Client boundaries decide
