### PR TITLE
feat(sdk): add optional Agent names for diagnostics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -340,6 +340,7 @@ Props:
 interface AgentProps {
   children?: AmlRenderable
   model?: string
+  name?: string
   permissions?: {
     filesystem?: "read-only" | "read-write"
     network?: boolean
@@ -353,6 +354,8 @@ interface AgentProps {
 `provider` selects the harness for this Agent. When omitted, AML uses `AmlRuntimeOptions.agentProvider`. An Agent without either provider is invalid. Different Agents in one evaluation may select different providers while remaining in the same evaluation domain.
 
 `model` is a provider-neutral override whose string remains provider-owned. Resolution order is the Agent `model` prop, then the configured provider's default, then the provider-native default. AML passes the explicit prop through `AgentRequest.model`; the selected provider rejects identifiers it cannot use.
+
+`name` is optional diagnostic metadata for relating traces and failures to the authored workflow. It must be a non-empty normalized string when supplied. Names are not unique: structural identities such as trace span IDs continue to distinguish Agents with the same name. AML includes the name in observability and diagnostics only; it never adds it to the prompt or system instructions sent to the provider.
 
 `system` is the concise fixed-text system prompt. `<System>` is the composable form for resolved asynchronous content. Provider-specific settings that have no portable AML semantics belong to configured provider instances, not arbitrary Agent props or an untyped `providerOptions` bag.
 
@@ -382,6 +385,7 @@ interface AgentPlan {
   followUps: readonly string[]
   mcpServers: readonly AgentMcpServer[]
   model?: string
+  name?: string
   permissions: AgentPermissions
   system: string
   systemFragments: readonly string[]
@@ -1742,6 +1746,7 @@ interface AgentRequest {
   followUps?: readonly string[]
   mcpServers: readonly AgentMcpServer[]
   model?: string
+  name?: string
   permissions: AgentPermissions
   output?: {
     jsonSchema: Readonly<Record<string, AmlJsonValue>>

--- a/sdk/src/components/agent/abstract-agent-provider.ts
+++ b/sdk/src/components/agent/abstract-agent-provider.ts
@@ -43,6 +43,7 @@ export abstract class AbstractAgentProvider<Name extends string> implements Agen
     const sessionTrace = observability.createTrace(context.trace.spanId)
     const sessionSpan = observability.startSpan(sessionTrace, "agent.session", {
       ...(request.model === undefined ? {} : { model: request.model }),
+      ...(request.name === undefined ? {} : { name: request.name }),
       provider: this.name,
     })
     // Session setup can emit process and ACP creation events before turn one.

--- a/sdk/src/components/agent/agent-diagnostic-identity.ts
+++ b/sdk/src/components/agent/agent-diagnostic-identity.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats authored Agent metadata without replacing its provider or trace identity.
+ */
+export function agentDiagnosticIdentity(input: {
+  readonly name: string | undefined
+  readonly provider?: string
+  readonly spanId: string
+}): string {
+  if (input.provider === undefined && input.name === undefined) {
+    return `Agent ${input.spanId}`
+  }
+
+  const provider = input.provider === undefined ? "Agent" : `Agent "${input.provider}"`
+  const name = input.name === undefined ? "" : ` [name: "${input.name}"]`
+
+  return `${provider}${name} (${input.spanId})`
+}

--- a/sdk/src/components/agent/agent-execution-result.ts
+++ b/sdk/src/components/agent/agent-execution-result.ts
@@ -1,6 +1,7 @@
 import { ComponentEvaluationContext } from "../../core/component-evaluation-context.js"
 import { EvaluationError } from "../../core/evaluation-error.js"
 import type { AmlTraceAttribute } from "../../observability/trace-event.js"
+import { agentDiagnosticIdentity } from "./agent-diagnostic-identity.js"
 import type { ModelSchema } from "./model-schema.js"
 import type { AgentResponse } from "./agent-response.js"
 import type { ValidatedAgentProvider } from "./validate-agent-provider.js"
@@ -32,6 +33,7 @@ export class AgentExecutionResult {
   static async from(input: {
     readonly mcpServers: number
     readonly model: string | undefined
+    readonly name: string | undefined
     readonly output: ModelSchema<unknown> | undefined
     readonly prompt: string
     readonly provider: Readonly<ValidatedAgentProvider>
@@ -41,7 +43,12 @@ export class AgentExecutionResult {
     readonly tools: number
     readonly turns: number
   }): Promise<AgentExecutionResult> {
-    const invalidResponse = `Agent "${input.provider.name}" (${input.spanId}) returned an invalid response`
+    const identity = agentDiagnosticIdentity({
+      name: input.name,
+      provider: input.provider.name,
+      spanId: input.spanId,
+    })
+    const invalidResponse = `${identity} returned an invalid response`
 
     if (typeof input.response !== "object" || input.response === null) {
       throw new EvaluationError(invalidResponse)
@@ -76,6 +83,7 @@ export class AgentExecutionResult {
         structured: await AgentExecutionResult.#structured(
           input.response,
           input.output,
+          input.name,
           input.provider.name,
           input.spanId
         ),
@@ -88,6 +96,7 @@ export class AgentExecutionResult {
       Object.freeze({
         mcpServers: input.mcpServers,
         ...(input.model === undefined ? {} : { model: input.model }),
+        ...(input.name === undefined ? {} : { name: input.name }),
         provider: input.provider.name,
         tools: input.tools,
         turns: input.turns,
@@ -106,6 +115,7 @@ export class AgentExecutionResult {
   static async #structured(
     response: AgentResponse,
     output: ModelSchema<unknown>,
+    name: string | undefined,
     provider: string,
     spanId: string
   ): Promise<unknown> {
@@ -124,18 +134,26 @@ export class AgentExecutionResult {
       present = captured.present
       structured = captured.structured
     } catch (cause) {
-      throw new EvaluationError(`Agent "${provider}" (${spanId}) returned an invalid structured response`, { cause })
+      throw new EvaluationError(
+        `${agentDiagnosticIdentity({ name, provider, spanId })} returned an invalid structured response`,
+        { cause }
+      )
     }
 
     if (!present) {
-      throw new EvaluationError(`Agent "${provider}" (${spanId}) omitted structured output`)
+      throw new EvaluationError(`${agentDiagnosticIdentity({ name, provider, spanId })} omitted structured output`)
     }
 
     try {
       // Schema thenables and nested accessors stay outside component authority.
       return await ComponentEvaluationContext.withoutAccess(async () => await output.validate(structured))
     } catch (cause) {
-      throw new EvaluationError(`Agent "${provider}" (${spanId}) returned invalid structured output`, { cause })
+      throw new EvaluationError(
+        `${agentDiagnosticIdentity({ name, provider, spanId })} returned invalid structured output`,
+        {
+          cause,
+        }
+      )
     }
   }
 }

--- a/sdk/src/components/agent/agent-executor.ts
+++ b/sdk/src/components/agent/agent-executor.ts
@@ -5,6 +5,7 @@ import type { AmlTraceIdentity } from "../../core/trace-identity.js"
 import type { SandboxSession } from "../sandbox/sandbox-provider.js"
 import type { AgentMcpServer } from "../mcp/aml-mcp-server.js"
 import type { AgentTool } from "../tool/agent-tool.js"
+import { agentDiagnosticIdentity } from "./agent-diagnostic-identity.js"
 import { AgentExecutionResult } from "./agent-execution-result.js"
 import type { ModelSchema } from "./model-schema.js"
 import type { AgentProps } from "./agent.js"
@@ -44,6 +45,13 @@ export class AgentExecutor {
   validateProps(props: Readonly<AgentProps>): Readonly<ValidatedAgentProvider> | undefined {
     if (props.model !== undefined && typeof props.model !== "string") {
       throw new EvaluationError("<Agent> model must be a string")
+    }
+
+    if (
+      props.name !== undefined &&
+      (typeof props.name !== "string" || props.name.length === 0 || props.name !== props.name.trim())
+    ) {
+      throw new EvaluationError("<Agent> name must be a non-empty normalized string")
     }
 
     if (props.system !== undefined && typeof props.system !== "string") {
@@ -93,8 +101,14 @@ export class AgentExecutor {
     readonly tools: readonly AgentTool[]
     readonly trace: AmlTraceIdentity
   }): Promise<Readonly<AgentExecutionResult>> {
+    const identity = agentDiagnosticIdentity({
+      name: input.props.name,
+      ...(input.provider === undefined ? {} : { provider: input.provider.name }),
+      spanId: input.trace.spanId,
+    })
+
     if (!input.provider) {
-      throw new EvaluationError(`Agent ${input.trace.spanId} has no provider`)
+      throw new EvaluationError(`${identity} has no provider`)
     }
 
     const provider = input.provider
@@ -112,15 +126,21 @@ export class AgentExecutor {
             Reflect.apply(supportsSandbox, provider.provider, [input.sandbox])
           ) === true
       } catch (cause) {
-        throw new EvaluationError(`Agent provider "${input.provider.name}" failed its Sandbox compatibility check`, {
+        const message =
+          input.props.name === undefined
+            ? `Agent provider "${input.provider.name}" failed its Sandbox compatibility check`
+            : `${identity} failed its Sandbox compatibility check`
+        throw new EvaluationError(message, {
           cause,
         })
       }
 
       if (!supported) {
-        throw new EvaluationError(
-          `Agent provider "${input.provider.name}" cannot run inside Sandbox provider "${input.sandbox.provider.name}"`
-        )
+        const message =
+          input.props.name === undefined
+            ? `Agent provider "${input.provider.name}" cannot run inside Sandbox provider "${input.sandbox.provider.name}"`
+            : `${identity} cannot run inside Sandbox provider "${input.sandbox.provider.name}"`
+        throw new EvaluationError(message)
       }
     }
 
@@ -141,7 +161,7 @@ export class AgentExecutor {
 
     // Reserve only after the complete plan exists. Limit errors belong to AML,
     // not the provider failure boundary below.
-    input.context.reserveAgentCall(input.trace)
+    input.context.reserveAgentCall(input.trace, input.props.name)
 
     let providerStarted = false
     let response: AgentResponse
@@ -161,18 +181,16 @@ export class AgentExecutor {
       })
     } catch (cause) {
       if (!providerStarted && input.context.signal.aborted) {
-        throw new EvaluationError(
-          `Agent "${provider.name}" (${input.trace.spanId}) was cancelled before provider execution`,
-          { cause }
-        )
+        throw new EvaluationError(`${identity} was cancelled before provider execution`, { cause })
       }
 
-      throw new EvaluationError(`Agent "${provider.name}" (${input.trace.spanId}) failed`, { cause })
+      throw new EvaluationError(`${identity} failed`, { cause })
     }
 
     return await AgentExecutionResult.from({
       mcpServers: input.mcpServers.length,
       model: plan.request.model,
+      name: plan.request.name,
       output: input.output,
       prompt: plan.prompt,
       provider,

--- a/sdk/src/components/agent/agent-request-plan.ts
+++ b/sdk/src/components/agent/agent-request-plan.ts
@@ -7,6 +7,7 @@ import type { AgentTool } from "../tool/agent-tool.js"
 import { instrumentAgentTools } from "../tool/instrument-agent-tools.js"
 import type { AgentProps } from "./agent.js"
 import type { AgentExecutionContext } from "./agent-execution-context.js"
+import { agentDiagnosticIdentity } from "./agent-diagnostic-identity.js"
 import { attachAgentObservabilityServices, agentObservabilityServices } from "./agent-observability-services.js"
 import { attachAgentStructuredOutputServices } from "./agent-structured-output-services.js"
 import type { ModelSchema } from "./model-schema.js"
@@ -82,7 +83,8 @@ export class AgentRequestPlan {
     const turnCount = 1 + followUps.length
 
     if (input.maxTurns !== 0 && turnCount > input.maxTurns) {
-      throw new EvaluationError(`Agent ${input.trace.spanId} exceeded maxTurnsPerAgent ${input.maxTurns}`)
+      const identity = agentDiagnosticIdentity({ name: input.props.name, spanId: input.trace.spanId })
+      throw new EvaluationError(`${identity} exceeded maxTurnsPerAgent ${input.maxTurns}`)
     }
 
     const tools = instrumentAgentTools(input.tools, input.context, input.trace)
@@ -95,6 +97,7 @@ export class AgentRequestPlan {
     const request: AgentRequest = Object.freeze({
       ...(followUps.length === 0 ? {} : { followUps: Object.freeze(followUps) }),
       ...(input.props.model === undefined ? {} : { model: input.props.model }),
+      ...(input.props.name === undefined ? {} : { name: input.props.name }),
       mcpServers: input.mcpServers,
       ...(input.output === undefined
         ? {}

--- a/sdk/src/components/agent/agent-request.ts
+++ b/sdk/src/components/agent/agent-request.ts
@@ -14,6 +14,8 @@ export interface AgentRequest {
   readonly followUps?: readonly string[]
   readonly mcpServers: readonly AgentMcpServer[]
   readonly model?: string
+  /** Optional authored metadata used only for diagnostics and tracing. */
+  readonly name?: string
   readonly output?: AgentOutputRequest
   readonly permissions: AgentPermissions
   readonly prompt: string

--- a/sdk/src/components/agent/agent.tsx
+++ b/sdk/src/components/agent/agent.tsx
@@ -23,6 +23,7 @@ export interface AgentProps {
   readonly children?: AmlRenderable
   readonly cwd?: string
   readonly model?: string
+  readonly name?: string
   readonly permissions?: AgentPermissionOverrides
   readonly provider?: AgentProvider
   readonly system?: string

--- a/sdk/src/core/evaluation-context.ts
+++ b/sdk/src/core/evaluation-context.ts
@@ -162,11 +162,12 @@ export class EvaluationContext {
   /**
    * Reserves one provider call before it enters the scheduler.
    */
-  reserveAgentCall(trace: AmlTraceIdentity): void {
+  reserveAgentCall(trace: AmlTraceIdentity, name?: string): void {
     this.#signal.throwIfAborted()
 
     if (this.#maxAgentCalls !== 0 && this.#agentCalls >= this.#maxAgentCalls) {
-      throw new EvaluationError(`AML evaluation exceeded maxAgentCalls ${this.#maxAgentCalls} at Agent ${trace.spanId}`)
+      const identity = name === undefined ? `Agent ${trace.spanId}` : `Agent [name: "${name}"] (${trace.spanId})`
+      throw new EvaluationError(`AML evaluation exceeded maxAgentCalls ${this.#maxAgentCalls} at ${identity}`)
     }
 
     this.#agentCalls += 1

--- a/sdk/tests/acp-observability.test.tsx
+++ b/sdk/tests/acp-observability.test.tsx
@@ -31,6 +31,24 @@ import { createAgentExecutionContext } from "../src/testing/create-agent-executi
 import { DeterministicSandboxProvider } from "../src/testing/deterministic-sandbox-provider.js"
 
 describe("ACP Agent observability", () => {
+  it("preserves unnamed Agent session and terminal attribute shapes", async () => {
+    const events: AmlTraceEvent[] = []
+    const provider = new ScriptedAcpProvider([script([], { stopReason: "end_turn" })])
+
+    await new AmlRuntime({ trace: event => events.push(event) }).evaluate(<Agent provider={provider}>prompt</Agent>)
+
+    const agentEnd = events.find(event => event.type === "span.end" && event.name === "Agent")
+    const sessionStart = events.find(event => event.type === "span.start" && event.name === "agent.session")
+
+    expect(sessionStart?.attributes).toEqual({ provider: "scripted-acp" })
+    expect(agentEnd?.attributes).toEqual({
+      mcpServers: 0,
+      provider: "scripted-acp",
+      tools: 0,
+      turns: 1,
+    })
+  })
+
   it("traces actual two-turn lifecycle order around streamed ACP updates", async () => {
     const events: AmlTraceEvent[] = []
     const provider = new ScriptedAcpProvider([
@@ -71,7 +89,7 @@ describe("ACP Agent observability", () => {
 
     await expect(
       new AmlRuntime({ trace: event => events.push(event) }).evaluate(
-        <Agent provider={provider}>
+        <Agent name="researcher" provider={provider}>
           first prompt
           <FollowUp>second prompt</FollowUp>
         </Agent>
@@ -123,9 +141,11 @@ describe("ACP Agent observability", () => {
       },
     })
 
+    const agentEnd = events.find(event => event.type === "span.end" && event.name === "Agent")
     const sessionStart = events.find(event => event.type === "span.start" && event.name === "agent.session")
     const cleanupStart = events.find(event => event.type === "span.start" && event.name === "agent.cleanup")
-    expect(sessionStart).toMatchObject({ attributes: { provider: "scripted-acp" } })
+    expect(agentEnd).toMatchObject({ attributes: { name: "researcher", provider: "scripted-acp" } })
+    expect(sessionStart).toMatchObject({ attributes: { name: "researcher", provider: "scripted-acp" } })
     expect(turns[0]).toMatchObject({ parentSpanId: sessionStart?.spanId })
     expect(cleanupStart).toMatchObject({ parentSpanId: sessionStart?.spanId })
   })

--- a/sdk/tests/agent-runtime.test.tsx
+++ b/sdk/tests/agent-runtime.test.tsx
@@ -41,6 +41,7 @@ describe("Agent", () => {
 
     expect(runtimeProvider.calls).toHaveLength(1)
     expect(runtimeProvider.calls[0]?.request.model).toBeUndefined()
+    expect(runtimeProvider.calls[0]?.request).not.toHaveProperty("name")
     expect(runtimeProvider.calls[0]?.request.permissions).toEqual({
       filesystem: "read-write",
       network: true,
@@ -77,6 +78,42 @@ describe("Agent", () => {
         <Agent permissions={{ shell: "yes" as never }}>invalid</Agent>
       )
     ).rejects.toThrow("<Agent> permissions.shell must be a boolean")
+  })
+
+  it("threads duplicate diagnostic names without changing provider content", async () => {
+    const events: AmlTraceEvent[] = []
+    const provider = new DeterministicAgentProvider({
+      respond: request => ({ text: request.prompt }),
+    })
+
+    await expect(
+      new AmlRuntime({ trace: event => events.push(event) }).evaluate([
+        <Agent name="reviewer" provider={provider} system="first system">
+          first prompt
+        </Agent>,
+        <Agent name="reviewer" provider={provider} system="second system">
+          second prompt
+        </Agent>,
+      ])
+    ).resolves.toBe("first promptsecond prompt")
+
+    expect(provider.calls.map(call => call.request.name)).toEqual(["reviewer", "reviewer"])
+    expect(provider.calls.map(call => call.request.prompt)).toEqual(["first prompt", "second prompt"])
+    expect(provider.calls.map(call => call.request.system)).toEqual(["first system", "second system"])
+
+    const agentEnds = events.filter(event => event.type === "span.end" && event.kind === "agent")
+    expect(agentEnds).toHaveLength(2)
+    expect(agentEnds.map(event => event.attributes.name)).toEqual(["reviewer", "reviewer"])
+    expect(new Set(agentEnds.map(event => event.spanId)).size).toBe(2)
+  })
+
+  it.each(["", " reviewer ", 42] as const)("rejects invalid diagnostic name %j", async name => {
+    const provider = new DeterministicAgentProvider()
+
+    await expect(
+      new AmlRuntime({ agentProvider: provider }).evaluate(<Agent name={name as never}>prompt</Agent>)
+    ).rejects.toThrow("<Agent> name must be a non-empty normalized string")
+    expect(provider.calls).toHaveLength(0)
   })
 
   it("resolves child Agents and System subtrees before their parent", async () => {
@@ -243,6 +280,24 @@ describe("Agent", () => {
 
     expect(error).toBeInstanceOf(EvaluationError)
     expect(error).toHaveProperty("message", 'Agent "broken" (span-1) failed')
+    expect(error).toHaveProperty("cause", failure)
+  })
+
+  it("adds the diagnostic name without replacing provider or span identity in failures", async () => {
+    const failure = new Error("provider exploded")
+    const provider: AgentProvider = {
+      name: "broken",
+      async run() {
+        throw failure
+      },
+    }
+
+    const error = await new AmlRuntime({ agentProvider: provider })
+      .evaluate(<Agent name="reviewer">prompt</Agent>)
+      .catch((cause: unknown) => cause)
+
+    expect(error).toBeInstanceOf(EvaluationError)
+    expect(error).toHaveProperty("message", 'Agent "broken" [name: "reviewer"] (span-1) failed')
     expect(error).toHaveProperty("cause", failure)
   })
 


### PR DESCRIPTION
closes #10

## Description

Adds an optional normalized `name` to `<Agent>` so authored Agents can be identified in traces and failures without changing provider prompts or requiring unique names.

## What changed?

- Threads `name` through the Agent request plan as observational metadata.
- Adds the name to runtime terminal spans, provider session spans, and Agent diagnostics while retaining provider and span identity.
- Preserves the exact unnamed request and trace attribute shapes.
- Documents the public contract and covers named, unnamed, invalid, and duplicate-name behavior.

## Verification

- `npm run format:check` passed across 454 files.
- `npm run lint` passed all 17 Turbo tasks.
- `npm test` passed all 17 Turbo tasks, including 310 SDK tests.
- `npm run build` passed all 14 Turbo tasks.
- The self-review exercised duplicate names with distinct span IDs and confirmed names do not alter prompt or system content.

> Names light the trace path
> Span IDs keep branches distinct
> Prompts stay untouched
