### PR TITLE
fix(agent-opencode): inherit permissions in native subagents

### DIFF
--- a/apps/website/src/content/docs/docs/providers/agents/codex.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/codex.mdx
@@ -153,6 +153,8 @@ The effective values are resolved as follows:
 | `shell: false`             | No additional Codex-native mapping is claimed by this profile.            | Use a Sandbox that rejects shell execution.                                 |
 | `network: false`           | No additional Codex-native mapping is claimed by this profile.            | Use a Sandbox or deployment network policy that enforces it.                |
 
+Codex native subagents inherit the parent turn's effective Codex permission profile and approval policy. AML leaves multi-agent execution enabled, so a subagent spawned after AML sets the Codex ACP adapter's `INITIAL_AGENT_MODE=read-only` remains read-only. This inheritance does not add Codex-native mappings for `shell: false` or `network: false`; those restrictions still depend on the enclosing Sandbox.
+
 ## Failure modes and troubleshooting
 
 <Steps>

--- a/apps/website/src/content/docs/docs/providers/agents/opencode.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/opencode.mdx
@@ -174,7 +174,7 @@ Model precedence is:
 2. `opencodeAgent({ model: "..." })`
 3. `opencodeAgent({ config: { model: "..." } })`
 
-AML sets `default_agent` to `aml` and merges the existing `config.agent` table, replacing the `aml` profile with the session-specific profile. This profile is `mode: "primary"` and exposes only the tools allowed by AML's normalized permission request.
+AML sets `default_agent` to `aml` and merges the existing `config.agent` table, replacing the `aml` profile with the session-specific profile. This profile is `mode: "primary"` and exposes only the tools allowed by AML's normalized permission request. AML also merges its deny rules into the top-level OpenCode permission policy, which OpenCode applies to every native agent profile. Native `task` subagents therefore inherit the parent AML restrictions without disabling delegation.
 
 OpenCode replaces its model-specific base coding prompt when a custom Agent has a non-empty `prompt`, so AML does not set that field. ACP has no system-message field; when the effective AML System text is non-empty, AML prepends it to the first user turn inside literal `<SYSTEM>` tags. Empty System content adds no prelude. This preserves OpenCode's native model-specific prompt, but the ACP protocol still carries the prelude as user-role content.
 
@@ -188,6 +188,8 @@ OpenCode replaces its model-specific base coding prompt when a custom Agent has 
 | Default permission        | Keeps tools enabled                 | Uses the AML profile's allow policy |
 
 These mappings are provider-native controls. They do not grant access beyond the enclosing Sandbox, and an OpenCode policy cannot make a read-only Sandbox writable. Conversely, a writable host Sandbox is not made safe merely because an Agent prompt asks it to be careful.
+
+Configured top-level permissions are preserved, but AML deny rules take precedence for a restricted evaluation. Child agents may narrow that policy further; they cannot regain filesystem, shell, or network tools denied by the parent AML request.
 
 ## State isolation and lifecycle
 

--- a/providers/agents/codex/src/codex-agent.ts
+++ b/providers/agents/codex/src/codex-agent.ts
@@ -57,8 +57,28 @@ class CodexProfile implements AcpAgentProfile<"codex"> {
 
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
     const model = context.request.model ?? this.#options.model
+    const hasRestrictedPermissions =
+      context.request.permissions.filesystem === "read-only" ||
+      !context.request.permissions.shell ||
+      !context.request.permissions.network
+    const configuredFeatures = this.#options.config.features
     const config = {
       ...this.#options.config,
+      ...(hasRestrictedPermissions
+        ? {
+            features: {
+              ...(typeof configuredFeatures === "object" &&
+              configuredFeatures !== null &&
+              !Array.isArray(configuredFeatures)
+                ? configuredFeatures
+                : {}),
+              // Codex subagents share the session sandbox but can leave a
+              // denied operation pending. Keep restricted execution within
+              // the single AML-owned Agent session.
+              multi_agent: false,
+            },
+          }
+        : {}),
       ...(this.#options.reasoningEffort === undefined ? {} : { model_reasoning_effort: this.#options.reasoningEffort }),
       ...(model === undefined ? {} : { model }),
       ...(context.request.system.length === 0 ? {} : { developer_instructions: context.request.system }),

--- a/providers/agents/codex/src/codex-agent.ts
+++ b/providers/agents/codex/src/codex-agent.ts
@@ -57,28 +57,8 @@ class CodexProfile implements AcpAgentProfile<"codex"> {
 
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
     const model = context.request.model ?? this.#options.model
-    const hasRestrictedPermissions =
-      context.request.permissions.filesystem === "read-only" ||
-      !context.request.permissions.shell ||
-      !context.request.permissions.network
-    const configuredFeatures = this.#options.config.features
     const config = {
       ...this.#options.config,
-      ...(hasRestrictedPermissions
-        ? {
-            features: {
-              ...(typeof configuredFeatures === "object" &&
-              configuredFeatures !== null &&
-              !Array.isArray(configuredFeatures)
-                ? configuredFeatures
-                : {}),
-              // Codex subagents share the session sandbox but can leave a
-              // denied operation pending. Keep restricted execution within
-              // the single AML-owned Agent session.
-              multi_agent: false,
-            },
-          }
-        : {}),
       ...(this.#options.reasoningEffort === undefined ? {} : { model_reasoning_effort: this.#options.reasoningEffort }),
       ...(model === undefined ? {} : { model }),
       ...(context.request.system.length === 0 ? {} : { developer_instructions: context.request.system }),

--- a/providers/agents/codex/tests/codex-agent.integration.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.integration.test.tsx
@@ -1,4 +1,5 @@
-import { cp, mkdtemp, rm } from "node:fs/promises"
+import { randomUUID } from "node:crypto"
+import { access, cp, mkdtemp, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 
@@ -8,6 +9,36 @@ import { expect, it } from "vitest"
 import { codexAgent } from "../src/index.js"
 
 const liveTest = process.env.AML_CODEX_ACP_LIVE === "1" ? it : it.skip
+
+liveTest(
+  "does not let native Codex subagents widen restricted Agent permissions",
+  async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "aml-codex-acp-"))
+    const codexHome = await mkdtemp(path.join(os.tmpdir(), "aml-codex-acp-home-"))
+    const outsidePath = path.join(os.tmpdir(), `aml-codex-subagent-${randomUUID()}`)
+    await cp(path.join(os.homedir(), ".codex", "auth.json"), path.join(codexHome, "auth.json"))
+    const provider = codexAgent({ env: { CODEX_HOME: codexHome }, workingDirectory: workspace })
+
+    try {
+      const output = await new AmlRuntime({ agentProvider: provider }).evaluate(
+        <Agent permissions={{ filesystem: "read-only", network: false, shell: false }}>
+          Start a subagent and ask it to run `touch {outsidePath}`. Report whether it succeeded.
+        </Agent>,
+        { signal: AbortSignal.timeout(60_000) }
+      )
+
+      await expect(access(outsidePath)).rejects.toThrow()
+      expect(output).toBeTruthy()
+    } finally {
+      await Promise.all([
+        rm(workspace, { force: true, recursive: true }),
+        rm(codexHome, { force: true, recursive: true }),
+        rm(outsidePath, { force: true }),
+      ])
+    }
+  },
+  90_000
+)
 
 liveTest(
   "runs Codex through the published ACP adapter on the trusted local launcher",

--- a/providers/agents/codex/tests/codex-agent.integration.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.integration.test.tsx
@@ -16,19 +16,21 @@ liveTest(
     const workspace = await mkdtemp(path.join(os.tmpdir(), "aml-codex-acp-"))
     const codexHome = await mkdtemp(path.join(os.tmpdir(), "aml-codex-acp-home-"))
     const outsidePath = path.join(os.tmpdir(), `aml-codex-subagent-${randomUUID()}`)
+    const childMarker = randomUUID()
     await cp(path.join(os.homedir(), ".codex", "auth.json"), path.join(codexHome, "auth.json"))
     const provider = codexAgent({ env: { CODEX_HOME: codexHome }, workingDirectory: workspace })
 
     try {
       const output = await new AmlRuntime({ agentProvider: provider }).evaluate(
         <Agent permissions={{ filesystem: "read-only", network: false, shell: false }}>
-          Start a subagent and ask it to run `touch {outsidePath}`. Report whether it succeeded.
+          Start a subagent. Tell it to attempt `touch {outsidePath}`, then return exactly the marker `{childMarker}`
+          whether the command succeeds or fails. After the subagent completes, return its marker.
         </Agent>,
         { signal: AbortSignal.timeout(60_000) }
       )
 
       await expect(access(outsidePath)).rejects.toThrow()
-      expect(output).toBeTruthy()
+      expect(output).toContain(childMarker)
     } finally {
       await Promise.all([
         rm(workspace, { force: true, recursive: true }),

--- a/providers/agents/codex/tests/codex-agent.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.test.tsx
@@ -105,7 +105,7 @@ describe("codexAgent()", () => {
     expect(config).toMatchObject({ model: "provider-model" })
   })
 
-  it("disables native subagents when portable Agent permissions are restricted", async () => {
+  it("preserves native subagent configuration when portable Agent permissions are restricted", async () => {
     let config: Record<string, unknown> | undefined
     const sandboxProvider = new DeterministicSandboxProvider({
       exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
@@ -125,7 +125,7 @@ describe("codexAgent()", () => {
       )
     ).rejects.toThrow()
 
-    expect(config).toMatchObject({ features: { apps: true, multi_agent: false } })
+    expect(config).toMatchObject({ features: { apps: true, multi_agent: true } })
   })
 
   it.each(["max", "ultra"])("passes arbitrary reasoning effort %s through CODEX_CONFIG", async reasoningEffort => {

--- a/providers/agents/codex/tests/codex-agent.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.test.tsx
@@ -105,12 +105,14 @@ describe("codexAgent()", () => {
     expect(config).toMatchObject({ model: "provider-model" })
   })
 
-  it("preserves native subagent configuration when portable Agent permissions are restricted", async () => {
+  it("keeps native delegation enabled in the mapped read-only Codex mode", async () => {
     let config: Record<string, unknown> | undefined
+    let initialAgentMode: string | undefined
     const sandboxProvider = new DeterministicSandboxProvider({
       exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
       spawn(_command, _args, _request, options) {
         config = JSON.parse(options.env?.CODEX_CONFIG ?? "")
+        initialAgentMode = options.env?.INITIAL_AGENT_MODE
         return completedProcess()
       },
     })
@@ -126,6 +128,7 @@ describe("codexAgent()", () => {
     ).rejects.toThrow()
 
     expect(config).toMatchObject({ features: { apps: true, multi_agent: true } })
+    expect(initialAgentMode).toBe("read-only")
   })
 
   it.each(["max", "ultra"])("passes arbitrary reasoning effort %s through CODEX_CONFIG", async reasoningEffort => {

--- a/providers/agents/codex/tests/codex-agent.test.tsx
+++ b/providers/agents/codex/tests/codex-agent.test.tsx
@@ -105,6 +105,29 @@ describe("codexAgent()", () => {
     expect(config).toMatchObject({ model: "provider-model" })
   })
 
+  it("disables native subagents when portable Agent permissions are restricted", async () => {
+    let config: Record<string, unknown> | undefined
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn(_command, _args, _request, options) {
+        config = JSON.parse(options.env?.CODEX_CONFIG ?? "")
+        return completedProcess()
+      },
+    })
+
+    await expect(
+      new AmlRuntime({
+        agentProvider: codexAgent({ config: { features: { apps: true, multi_agent: true } } }),
+      }).evaluate(
+        <Sandbox provider={sandboxProvider}>
+          <Agent permissions={{ filesystem: "read-only", network: false, shell: false }}>Prompt</Agent>
+        </Sandbox>
+      )
+    ).rejects.toThrow()
+
+    expect(config).toMatchObject({ features: { apps: true, multi_agent: false } })
+  })
+
   it.each(["max", "ultra"])("passes arbitrary reasoning effort %s through CODEX_CONFIG", async reasoningEffort => {
     let config: Record<string, unknown> | undefined
     const sandboxProvider = new DeterministicSandboxProvider({

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -32,6 +32,7 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
     const tools: Record<string, boolean> = { "*": true }
     const permission: Record<string, "allow" | "deny"> = { "*": "allow" }
+    const inheritedPermission: Record<string, "deny"> = {}
 
     // OpenCode exposes more granular controls than ACP. Translate the portable
     // request here while the outer Sandbox remains the hard boundary.
@@ -40,11 +41,13 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
       tools.write = false
       permission.edit = "deny"
       permission.write = "deny"
+      inheritedPermission.edit = "deny"
     }
 
     if (!context.request.permissions.shell) {
       tools.bash = false
       permission.bash = "deny"
+      inheritedPermission.bash = "deny"
     }
 
     if (!context.request.permissions.network) {
@@ -52,21 +55,15 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
       tools.websearch = false
       permission.webfetch = "deny"
       permission.websearch = "deny"
-    }
-
-    if (
-      context.request.permissions.filesystem === "read-only" ||
-      !context.request.permissions.shell ||
-      !context.request.permissions.network
-    ) {
-      // Native task subagents have their own OpenCode profile and can widen the
-      // portable Agent permissions. Restricted sessions therefore cannot
-      // delegate outside the AML-owned Agent boundary.
-      tools.task = false
-      permission.task = "deny"
+      inheritedPermission.webfetch = "deny"
+      inheritedPermission.websearch = "deny"
     }
 
     const configuredAgents = configTable(this.#options.config.agent)
+    const configuredPermission =
+      typeof this.#options.config.permission === "string"
+        ? { "*": this.#options.config.permission }
+        : (this.#options.config.permission ?? {})
     const model = context.request.model ?? this.#options.model ?? this.#options.config.model
     const config: Config = {
       ...this.#options.config,
@@ -79,6 +76,9 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
         },
       },
       default_agent: "aml",
+      // OpenCode derives native child-session permissions from top-level deny
+      // rules, so task subagents inherit the portable AML restrictions.
+      permission: { ...configuredPermission, ...inheritedPermission },
       ...(model === undefined ? {} : { model }),
     }
 

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -76,8 +76,8 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
         },
       },
       default_agent: "aml",
-      // OpenCode derives native child-session permissions from top-level deny
-      // rules, so task subagents inherit the portable AML restrictions.
+      // OpenCode merges top-level permissions into every native agent profile,
+      // so task subagents receive the same portable AML restrictions.
       permission: { ...configuredPermission, ...inheritedPermission },
       ...(model === undefined ? {} : { model }),
     }

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -54,6 +54,18 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
       permission.websearch = "deny"
     }
 
+    if (
+      context.request.permissions.filesystem === "read-only" ||
+      !context.request.permissions.shell ||
+      !context.request.permissions.network
+    ) {
+      // Native task subagents have their own OpenCode profile and can widen the
+      // portable Agent permissions. Restricted sessions therefore cannot
+      // delegate outside the AML-owned Agent boundary.
+      tools.task = false
+      permission.task = "deny"
+    }
+
     const configuredAgents = configTable(this.#options.config.agent)
     const model = context.request.model ?? this.#options.model ?? this.#options.config.model
     const config: Config = {

--- a/providers/agents/opencode/tests/opencode-agent.integration.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.integration.test.tsx
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { access, rm } from "node:fs/promises"
 
 import { Agent, type AmlTraceEvent, AmlRuntime, evaluate, FollowUp } from "@aml-jsx/sdk"
 import { expect, it } from "vitest"
@@ -7,6 +8,33 @@ import { z } from "zod"
 import { opencodeAgent } from "../src/index.js"
 
 const liveTest = process.env.AML_OPENCODE_LIVE === "1" ? it : it.skip
+
+liveTest(
+  "does not let a native task subagent widen restricted Agent permissions",
+  async () => {
+    const outsidePath = `/tmp/aml-opencode-native-task-${randomUUID()}`
+    const provider = opencodeAgent({
+      directory: process.cwd(),
+      model: process.env.AML_OPENCODE_MODEL ?? "opencode-go/minimax-m3",
+    })
+
+    try {
+      const output = await new AmlRuntime({ agentProvider: provider }).evaluate(
+        <Agent permissions={{ filesystem: "read-only", network: false, shell: false }}>
+          Use the native task tool to start the general subagent. Ask it to run the shell command `touch {outsidePath}`.
+          Report whether the subagent could run the command.
+        </Agent>,
+        { signal: AbortSignal.timeout(30_000) }
+      )
+
+      await expect(access(outsidePath)).rejects.toThrow()
+      expect(output).toBeTruthy()
+    } finally {
+      await rm(outsidePath, { force: true })
+    }
+  },
+  45_000
+)
 
 liveTest(
   "retains conversation history through the installed native OpenCode ACP Agent",

--- a/providers/agents/opencode/tests/opencode-agent.integration.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.integration.test.tsx
@@ -13,6 +13,7 @@ liveTest(
   "does not let a native task subagent widen restricted Agent permissions",
   async () => {
     const outsidePath = `/tmp/aml-opencode-native-task-${randomUUID()}`
+    const childMarker = randomUUID()
     const provider = opencodeAgent({
       directory: process.cwd(),
       model: process.env.AML_OPENCODE_MODEL ?? "opencode-go/minimax-m3",
@@ -21,14 +22,15 @@ liveTest(
     try {
       const output = await new AmlRuntime({ agentProvider: provider }).evaluate(
         <Agent permissions={{ filesystem: "read-only", network: false, shell: false }}>
-          Use the native task tool to start the general subagent. Ask it to run the shell command `touch {outsidePath}`.
-          Report whether the subagent could run the command.
+          Use the native task tool to start the general subagent. Tell the subagent to attempt the shell command `touch
+          {outsidePath}`, then return exactly the marker `{childMarker}` whether the command succeeds or fails. After
+          the subagent completes, return its marker.
         </Agent>,
         { signal: AbortSignal.timeout(30_000) }
       )
 
       await expect(access(outsidePath)).rejects.toThrow()
-      expect(output).toBeTruthy()
+      expect(output).toContain(childMarker)
     } finally {
       await rm(outsidePath, { force: true })
     }

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -134,7 +134,6 @@ describe("opencodeAgent()", () => {
             "*": "allow",
             bash: "deny",
             edit: "deny",
-            task: "deny",
             webfetch: "deny",
             websearch: "deny",
             write: "deny",
@@ -143,14 +142,21 @@ describe("opencodeAgent()", () => {
             "*": true,
             bash: false,
             edit: false,
-            task: false,
             webfetch: false,
             websearch: false,
             write: false,
           },
         },
       },
+      permission: {
+        bash: "deny",
+        edit: "deny",
+        webfetch: "deny",
+        websearch: "deny",
+      },
     })
+    expect(config).not.toHaveProperty("agent.aml.permission.task")
+    expect(config).not.toHaveProperty("agent.aml.tools.task")
     expect(config).not.toHaveProperty("instructions")
     expect((config.agent as { aml: unknown }).aml).not.toHaveProperty("prompt")
   })

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -130,8 +130,24 @@ describe("opencodeAgent()", () => {
     expect(config).toMatchObject({
       agent: {
         aml: {
-          permission: { "*": "allow", bash: "deny", edit: "deny", webfetch: "deny", websearch: "deny", write: "deny" },
-          tools: { "*": true, bash: false, edit: false, webfetch: false, websearch: false, write: false },
+          permission: {
+            "*": "allow",
+            bash: "deny",
+            edit: "deny",
+            task: "deny",
+            webfetch: "deny",
+            websearch: "deny",
+            write: "deny",
+          },
+          tools: {
+            "*": true,
+            bash: false,
+            edit: false,
+            task: false,
+            webfetch: false,
+            websearch: false,
+            write: false,
+          },
         },
       },
     })

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -116,7 +116,7 @@ describe("opencodeAgent()", () => {
         return completedProcess()
       },
     })
-    const provider = opencodeAgent()
+    const provider = opencodeAgent({ config: { permission: { bash: "allow", question: "deny" } } })
 
     await expect(
       new AmlRuntime({ agentProvider: provider }).evaluate(
@@ -151,6 +151,7 @@ describe("opencodeAgent()", () => {
       permission: {
         bash: "deny",
         edit: "deny",
+        question: "deny",
         webfetch: "deny",
         websearch: "deny",
       },


### PR DESCRIPTION
closes #20

## Description

Ensure OpenCode native task subagents inherit restricted AML Agent permissions without disabling delegation.

## What changed?

- Publish AML filesystem, shell, and network deny rules through OpenCode's top-level permission policy.
- Keep the parent Agent's native `task` tool enabled and preserve configured permissions, with AML restrictions taking precedence.
- Add bounded live regressions for delegated outside-workspace writes through OpenCode and Codex.
- Document the OpenCode shared permission layer and the Codex ACP adapter inheritance boundary.
- Check Copilot, GLM, and Pi for equivalent native child-agent paths; none expose the same provider-owned delegation surface.

## Why permissions are inherited

- OpenCode 1.18.18 merges its top-level permission policy into every native agent profile. Its task implementation authorizes child tools against the selected child profile plus child-session rules. AML now supplies its deny map at that shared layer.
- Codex ACP maps AML read-only filesystem access to Codex read-only mode. Codex 0.147.0 builds a spawned child from the parent turn config and explicitly copies the live permission profile and approval policy. AML leaves multi-agent enabled.
- Codex shell and network restrictions remain the responsibility of the enclosing AML Sandbox; this PR does not claim an additional Codex-native mapping for them.

## Verification

- OpenCode unit coverage proves `task` remains enabled, configured permissions survive, and AML denies win in the shared policy.
- Codex unit coverage proves multi-agent remains enabled while AML launches the read-only Codex mode.
- Focused live OpenCode and Codex tests require the delegated flow to return a per-run marker, settle within a deadline, and leave the forbidden outside-workspace file absent.
- Provider lint and unit suites pass.
- Full pre-push format, lint, test, and build checks pass.
