### PR TITLE
feat(sdk): support nested and recoverable structured output

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -80,6 +80,10 @@ Without an active Sandbox, `<Agent>` runs according to its provider and `<Script
 
 Unknown provider and Tool data is validated at the boundary where it enters AML. Model-facing structured data must also provide JSON Schema.
 
+Structured output has two explicit owners. An Agent `schema` prop keeps the result in ordinary AML composition as canonical JSON text, which lets nested Agents feed validated data into later prompts. Component-local `evaluate(value, schema)` is the typed collection boundary for application decisions. One Agent cannot use both forms.
+
+FollowUps remain ordered turns in one provider-owned session. A structured contract applies only to the final authored turn, after every authored FollowUp has run. For built-in ACP profiles, omission of the submission Tool triggers exactly one shared-engine repair prompt containing the profile-specific Tool instruction and complete JSON Schema; a second omission fails the Agent. This bounded protocol recovery is owned by AML's shared ACP engine rather than individual profiles and does not establish a general workflow retry policy.
+
 ### Explicit resource ownership
 
 Sandbox and Workspace scopes acquire, expose, save, and release resources through explicit provider contracts. Working directories are not treated as security boundaries.
@@ -168,7 +172,7 @@ Stable public API contains behavior accepted in `SPEC.md` and proven through pro
 
 AML separates three provider responsibilities:
 
-- The shared ACP engine owns built-in coding-agent sessions, authored turns, MCP bridges, streaming, cancellation, and cleanup.
+- The shared ACP engine owns built-in coding-agent sessions, authored turns, MCP bridges, structured-output submission and bounded repair, streaming, cancellation, and cleanup.
 - Agent profiles own ACP executable selection, model and system mapping, native permission mapping, credentials, and provider-specific configuration.
 - Sandbox providers own disposable execution environments and expose bounded command execution plus safe long-lived process spawning.
 - Workspace providers own durable materialization, optional cross-process locking, persistence, and release.
@@ -287,7 +291,7 @@ Research references:
 - Effect and Flue runtimes
 - React-style mutable state
 - durable resume and distributed scheduling
-- retry and repair policies
+- general workflow retry policies beyond structured-output protocol recovery
 - human approval gates
 - CLI and TUI
 - generic plugin infrastructure
@@ -310,7 +314,6 @@ These remain product questions until resolved into `SPEC.md`:
 - When, if ever, should JSX siblings become implicitly concurrent?
 - Which trace events are stable public API?
 - What is the first useful artifact contract for large data?
-- Where should retries and schema repair live?
 - What should an Agent provider expose about inherited host configuration?
 - Should a strict capability mode reject provider-inherited MCP servers that cannot be disabled?
 - Should local MCP server execution location be explicit, or remain entirely adapter-owned?

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ workflows with `@aml-jsx/sdk`.
 
 | Primitive     | Purpose                                                                                                              |
 | ------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `<Agent>`     | Runs one Agent session after its prompt, System content, capabilities, and child Agent results have resolved.        |
+| `<Agent>`     | Runs one Agent session and optionally validates its result with an Agent-owned `schema`.                             |
 | `<System>`    | Adds resolved content to the owning Agent's system prompt. Multiple System blocks are joined in authored order.      |
 | `<Tool>`      | Grants the owning Agent a JavaScript Tool created with `defineTool()`.                                               |
 | `<Skill>`     | Adds reusable inline or local-file instructions to the owning Agent.                                                 |
@@ -190,7 +190,7 @@ Every cell launches its Agent through the same shared ACP engine and `SandboxRun
 
 Docker, Daytona, and Modal smoke cells use `ghcr.io/we-are-singular/aml-agent-sandbox:dev`. Set `AML_SMOKE_SANDBOX_IMAGE` to run every image-backed cell against one explicit reference, such as an immutable version or digest. Provider factories default to `wearesingular/aml-agent-sandbox:latest`; applications can override it with their own image or snapshot.
 
-`<System>`, `<Skill>`, `<FollowUp>`, Context, and tree evaluation are runtime-owned. JavaScript Tools use one AML-owned invocation MCP bridge, and structured output uses one AML-owned final-turn submission Tool. Agent permissions default to read-write filesystem, shell, and network access; the active Sandbox remains the security boundary for model-controlled operations.
+`<System>`, `<Skill>`, `<FollowUp>`, Context, and tree evaluation are runtime-owned. JavaScript Tools use one AML-owned invocation MCP bridge. Structured output uses one AML-owned submission Tool on the final authored turn and one shared, schema-bearing repair prompt if that turn omits the Tool call. Agent permissions default to read-write filesystem, shell, and network access; the active Sandbox remains the security boundary for model-controlled operations.
 
 Provider factories retain typed vendor configuration and process environment inputs. Credentials normally remain in the selected host or Sandbox environment; an application may also pass explicit invocation environment variables without changing the AML tree.
 

--- a/SANDBOXING.md
+++ b/SANDBOXING.md
@@ -260,8 +260,10 @@ Agent-specific configuration, reject an unsupported MCP transport, or report tha
 enforceable. Those are profile capability differences, not reasons to fork the session lifecycle.
 
 JavaScript Tools use one AML-owned MCP bridge. Structured output uses one AML-owned MCP submission Tool on the final
-turn. Native Agent operations remain inside the Agent process; the outer Sandbox is their security boundary. ACP
-permission requests are workflow interactions and must not be represented as filesystem or process confinement.
+authored turn. If that turn omits the Tool call, the shared ACP engine sends one repair prompt with the Tool instruction
+and complete JSON Schema; Agent profiles do not own separate recovery algorithms. Native Agent operations remain
+inside the Agent process; the outer Sandbox is their security boundary. ACP permission requests are workflow
+interactions and must not be represented as filesystem or process confinement.
 
 ## Third-party Sandbox abstractions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -348,6 +348,7 @@ interface AgentProps {
     shell?: boolean
   }
   provider?: AgentProvider
+  schema?: AmlModelSchema<unknown, unknown>
   system?: string
   timeoutMs?: number
 }
@@ -364,6 +365,8 @@ interface AgentProps {
 `system` is the concise fixed-text system prompt. `<System>` is the composable form for resolved asynchronous content. Provider-specific settings that have no portable AML semantics belong to configured provider instances, not arbitrary Agent props or an untyped `providerOptions` bag.
 
 `timeoutMs`, when present, is a positive safe integer that bounds the provider session after it acquires an Agent scheduler slot. AML derives a session signal that aborts when either this timeout expires or the enclosing evaluation is cancelled; the earliest cause wins, and nested Agents retain independent scopes. Expiry follows the same provider cancellation path as caller cancellation. AML awaits provider-owned abort and cleanup before settling the Agent, and preserves both the cancellation cause and any later cleanup failure.
+
+`schema` declares structured output at this Agent boundary. The Agent receives the generated JSON Schema, AML validates the returned value, and ordinary tree composition receives the transformed result as canonical JSON text. Use component-local `evaluate(value, schema)` instead when TypeScript needs the inferred value. One Agent cannot declare both schema owners.
 
 `permissions` describes the native coding environment requested from the Agent harness. Omitted fields default optimistically to `{ filesystem: "read-write", network: true, shell: true }`: a coding Agent can inspect and edit its Workspace, execute commands, and use the network without repetitive `<Tool>` declarations. A profile maps these portable requests to its native controls and reports any control it cannot express exactly.
 
@@ -393,6 +396,7 @@ interface AgentPlan {
   model?: string
   name?: string
   permissions: AgentPermissions
+  schema?: AmlModelSchema<unknown, unknown>
   system: string
   systemFragments: readonly string[]
   tools: readonly AgentTool[]
@@ -468,7 +472,9 @@ AML evaluates these siblings left to right. Explicit `Promise.all(evaluate(...))
 
 ### 5.4 Agent result
 
-Without structured output, the Agent element resolves to the final assistant text from its session. With FollowUps, intermediate assistant responses remain in provider session history and traces but do not become AML output.
+Without a `schema`, the Agent element resolves to the final assistant text from its session. With `schema`, AML validates the structured response and inserts the transformed value into the surrounding tree as canonical JSON text with deterministically ordered object keys. A transformation that produces non-JSON data, including `undefined`, rejects at that Agent boundary.
+
+With FollowUps, intermediate assistant responses remain in provider session history and traces but do not become AML output. Structured output is requested only on the final authored turn.
 
 An Agent with one input returns that input's response. An Agent with FollowUps returns the response to the last successful FollowUp.
 
@@ -875,6 +881,14 @@ A `stdio` MCP server may run in the provider environment or inside the active Sa
 
 `AmlModelSchema<T>` is AML's structural contract for a schema that supports both Standard Schema validation and Standard JSON Schema generation. AML does not require one concrete schema library.
 
+An Agent may own this contract declaratively:
+
+```tsx
+<Agent schema={Research}>Return structured research.</Agent>
+```
+
+That form remains ordinary AML composition: the validated, transformed value renders as canonical JSON text in a parent prompt, File, System block, or root string result.
+
 `evaluate()` executes AML as component-local data:
 
 ```tsx
@@ -896,13 +910,13 @@ const Research = z.object({
 const research = await evaluate(<Agent>Return structured research.</Agent>, Research)
 ```
 
-With a schema, the supplied AML must resolve to exactly one Agent, optionally through Fragments, Context Providers, or ordinary function components. Non-empty text outside that Agent is invalid because it would create a second result channel. AML generates and snapshots draft 2020-12 JSON Schema before the provider boundary, sends that portable JSON document through `AgentRequest.output.jsonSchema`, and validates the provider's returned unknown value again through the original Standard Schema. Providers never receive or invoke the application-owned schema object. The component receives Standard Schema's inferred output, including an authored transformation; only the provider-facing value and JSON Schema must remain JSON.
+With a schema argument, the supplied AML must resolve to exactly one Agent, optionally through Fragments, Context Providers, or ordinary function components. Non-empty text outside that Agent is invalid because it would create a second result channel. AML generates and snapshots draft 2020-12 JSON Schema before the provider boundary, sends that portable JSON document through `AgentRequest.output.jsonSchema`, and validates the provider's returned unknown value again through the original Standard Schema. Providers never receive or invoke the application-owned schema object. The component receives Standard Schema's inferred output, including an authored transformation; only the provider-facing value and JSON Schema must remain JSON. An Agent `schema` prop cannot be combined with this evaluation-owned schema.
 
 `<Loop>` is invalid anywhere inside a schema-bearing `evaluate()` subtree, including the selected Agent's prompt, System, Skill, and FollowUp channels. A Loop may open multiple fresh Agent sessions and therefore cannot satisfy the structured call's exactly-one-Agent execution contract.
 
-With FollowUps, the schema applies only to the final turn.
+With FollowUps, either schema form applies only to the final authored turn.
 
-Built-in coding-agent providers implement this contract through one AML-owned, invocation-scoped MCP submission Tool supplied during ACP session creation. AML exposes that Tool only for a structured invocation, instructs the Agent profile to submit exactly one final value on the last authored turn, captures the submitted JSON value, and validates it through the original Standard Schema after the provider returns. ACP does not currently define a portable JSON Schema output field, so profiles must not implement separate vendor-native structured-output lifecycles. Missing, duplicate, premature, or invalid submissions reject the Agent.
+Built-in coding-agent providers implement this contract through one AML-owned, invocation-scoped MCP submission Tool supplied during ACP session creation. AML exposes that Tool only for a structured invocation, instructs the Agent profile to submit exactly one final value on the last authored turn, and validates every candidate immediately. Invalid or premature submissions return recoverable Tool errors; the first valid candidate wins and later candidates are ignored. If the final authored turn ends without an accepted candidate, the shared ACP session sends one repair prompt containing the provider-specific Tool instruction and complete JSON Schema. A second omission rejects the Agent. ACP does not currently define a portable JSON Schema output field, so profiles must not implement separate vendor-native structured-output lifecycles.
 
 ### 10.1 Invocation scope
 
@@ -1791,8 +1805,9 @@ An omitted or empty `followUps` array represents a single-input Agent. When Foll
 3. sends `prompt`
 4. sends each `followUps` entry after the preceding response
 5. applies structured output only to the final input
-6. returns only the final response
-7. disposes invocation-scoped Tool registrations and MCP connections after the session settles; if the provider cannot remove dynamic registrations, its adapter must use a disposable provider host or reject that capability rather than accumulate registrations in shared provider state
+6. for built-in ACP profiles, sends one schema-bearing repair prompt if that final input ends without an accepted result
+7. returns only the final response
+8. disposes invocation-scoped Tool registrations and MCP connections after the session settles; if the provider cannot remove dynamic registrations, its adapter must use a disposable provider host or reject that capability rather than accumulate registrations in shared provider state
 
 For built-in coding-agent providers, this lifecycle is implemented once by the shared ACP session engine. A profile supplies:
 
@@ -2055,7 +2070,7 @@ The event stream covers evaluation and component execution, Agent sessions and a
 
 Every event includes `runId`, `spanId`, a monotonically increasing evaluation-local `sequence`, and a Unix-millisecond `timestamp`. Nested events include `parentSpanId`. `span.end` reuses its `span.start` identity and reports non-negative elapsed milliseconds. An evaluation span is the root ancestor of every other span, including component-local `evaluate()` calls and concurrently scheduled Agents. Each lexical execution boundary is the direct parent of the subtree it evaluates: a component returning an Agent owns that Agent span, and Workspace, Sandbox, Loop, System, and Skill descendants remain beneath their corresponding spans.
 
-Agent spans begin when the runtime enters the authored Agent, before Agent-specific prop and Sandbox preflight, and include post-order request assembly plus the provider session. The runtime closes a successful Agent span only after its result enters the parent AML output channel. FollowUps remain inside that Agent span. `agent.turn` events are emitted in authored order at the provider handoff: the initial prompt is turn `1`, and the first FollowUp is turn `2`. Provider-internal reasoning, retries, tool loops, token accounting, and usage records are not part of the stable Slice 15 contract because the portable provider interface cannot observe them consistently.
+Agent spans begin when the runtime enters the authored Agent, before Agent-specific prop and Sandbox preflight, and include post-order request assembly plus the provider session. The runtime closes a successful Agent span only after its result enters the parent AML output channel. FollowUps remain inside that Agent span. `agent.turn` events are emitted in authored order at the provider handoff: the initial prompt is turn `1`, and the first FollowUp is turn `2`. A shared ACP structured-output repair prompt remains inside the final authored turn and emits its own ACP prompt events; it does not consume another authored-turn budget. Provider-internal reasoning, retries, tool loops, token accounting, and usage records are not part of the stable Slice 15 contract because the portable provider interface cannot observe them consistently.
 
 Trace sinks supplied through the compatibility `trace` runtime option are registered as `trace` event listeners. Each evaluation still owns its ordering counter, root span, and failure-warning state. A listener receives deeply immutable snapshots rather than request, response, Tool, provider, lease, or component objects. It runs outside component-local `evaluate()` access and cannot mutate workflow inputs or results through the event API.
 

--- a/apps/website/src/content/docs/docs/cookbook/structured-output.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/structured-output.mdx
@@ -81,6 +81,27 @@ synthesized:Explain this high finding: authorization is checked after mutation
 
 The deterministic provider returns a JSON-shaped value only when AML asks for JSON. The schema then validates that value before the typed `finding` is interpolated into the second `<Agent />`.
 
+## Structured nested Agents
+
+Use the Agent `schema` prop when a nested Agent should own validation without opening an imperative collection boundary:
+
+```tsx
+import { Agent, FollowUp } from "@aml-jsx/sdk"
+
+const workflow = (
+  <Agent provider={provider}>
+    Specialist finding:
+    <Agent provider={provider} schema={Finding}>
+      Inspect the change.
+      <FollowUp>Challenge the evidence, then submit the final finding.</FollowUp>
+    </Agent>
+    Synthesize the validated finding.
+  </Agent>
+)
+```
+
+The specialist's transformed result enters the parent prompt as canonical JSON text. FollowUps remain one ordered session; AML requests structured output only on the final authored turn. Use `evaluate(value, Finding)` instead when component code needs the schema-inferred value. The two forms are alternative schema owners and cannot be combined on one Agent.
+
 ## How it works
 
 <Steps>
@@ -88,7 +109,7 @@ The deterministic provider returns a JSON-shaped value only when AML asks for JS
 1. `evaluate(value, Finding)` requests structured output from the nearest Agent provider.
 2. AML converts the application-owned schema to JSON Schema for the provider request. Zod is one implementation of the Standard Schema contract.
 3. On the shared ACP path, the Agent submits candidates through AML's `aml_submit_result` MCP tool. AML immediately validates each candidate and returns validation errors to the Agent so it can correct the result in the same turn.
-4. The first valid candidate is accepted. Later submissions are ignored, while missing or never-valid output rejects the evaluation.
+4. The first valid candidate is accepted. Later submissions are ignored. If the final authored turn omits a valid candidate, AML sends one repair prompt with the Tool instruction and complete JSON Schema; a second omission rejects the evaluation.
 5. AML validates the accepted value at the application boundary before returning the schema's output type.
 6. The second `<Agent />` remains text-producing. In this example, structured output applies to the specialist, not to the final response.
 
@@ -101,7 +122,7 @@ The deterministic provider returns a JSON-shaped value only when AML asks for JS
 
 ## Failure and security notes
 
-- On the shared ACP path, invalid candidates are recoverable tool errors until the turn ends. Missing output, or a turn that ends without any valid candidate, rejects the evaluation.
+- On the shared ACP path, invalid candidates are recoverable Tool errors. A final authored turn without an accepted candidate receives one schema-bearing repair prompt; missing output after that repair rejects the evaluation.
 - After AML accepts the first valid candidate, repeated submissions cannot replace it. With tracing enabled, submissions appear as `agent.output` events with `invalid`, `accepted`, or `ignored` status.
 - The repository example uses a deterministic provider; it does not prove that every Agent provider supports the same native structured-output mechanism.
 - Do not treat a valid shape as authorization to perform an external side effect. Validate business rules before writing files, merging code, or sending messages.

--- a/apps/website/src/content/docs/docs/faq.mdx
+++ b/apps/website/src/content/docs/docs/faq.mdx
@@ -111,7 +111,9 @@ The [Tools guide](/docs/cookbook/tools/) starts with a local function. The [Tool
 
 ### Can I get predictable JSON instead of a prose answer?
 
-Yes. AML can ask an agent for structured output and validate the returned value with a Standard Schema-compatible library such as Zod before your TypeScript code receives it.
+Yes. Use `<Agent schema={Result}>` when a nested Agent's validated result should continue through the AML tree as canonical JSON text. Use component-local `evaluate(<Agent>...</Agent>, Result)` when TypeScript needs the schema-inferred value for an application decision.
+
+Both forms apply the structured contract only to the final authored turn, so ordered `<FollowUp>` prompts can run first. Built-in ACP providers send one explicit schema-bearing repair prompt if that final turn omits the result Tool.
 
 Validation proves that the value has the expected shape; it does not prove that the model's claims are true or authorized. See [structured output](/docs/cookbook/structured-output/) for a complete example.
 

--- a/apps/website/src/content/docs/docs/provider-authoring.mdx
+++ b/apps/website/src/content/docs/docs/provider-authoring.mdx
@@ -79,7 +79,7 @@ The image name and output budget belong to [`dockerSandbox()`](/docs/providers/s
 Implement an **Agent provider** when the external system owns a model or coding-harness session.
 
 - Use the direct `AgentProvider.run()` boundary for an internal service, deterministic harness, or protocol that already exposes one complete session operation.
-- Use AML's ACP profile boundary when the integration launches an ACP-compatible executable. The shared adapter owns process launch, ordered turns, MCP bridging, structured output, Sandbox execution, and cleanup; the profile owns command, arguments, environment, configuration, and capability translation.
+- Use AML's ACP profile boundary when the integration launches an ACP-compatible executable. The shared adapter owns process launch, ordered turns, MCP bridging, structured-output validation and bounded repair, Sandbox execution, and cleanup; the profile owns command, arguments, environment, configuration, and capability translation.
 - Use a retained provider session only when the integration genuinely has ordered turn state and invocation-scoped cleanup that cannot be represented as one direct call.
 
 Do not label a plain chat-completions call as a coding-agent integration unless it really provides the session, tools, permissions, and execution behavior the provider claims.

--- a/apps/website/src/content/docs/docs/providers/agents/index.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/index.mdx
@@ -189,7 +189,7 @@ MCP server identity, allowlists, transport configuration, and lifecycle belong t
 
 ### Structured output
 
-`evaluate(value, schema)` asks for one structured `<Agent />` result. Built-in ACP profiles submit candidates through the invocation-owned `aml_submit_result` MCP tool. AML validates each candidate immediately with the supplied Standard Schema: an invalid candidate is returned to the Agent as a tool error, the first valid candidate is accepted, and later submissions are ignored. A turn that ends without a valid candidate rejects the evaluation.
+`evaluate(value, schema)` asks for one typed structured `<Agent />` result; `<Agent schema={schema}>` validates a nested Agent and contributes canonical JSON text to ordinary composition. Built-in ACP profiles submit candidates through the invocation-owned `aml_submit_result` MCP tool. AML validates each candidate immediately with the supplied Standard Schema: an invalid candidate is returned to the Agent as a tool error, the first valid candidate is accepted, and later submissions are ignored. If the final authored turn ends without an accepted candidate, AML sends one repair prompt that repeats the provider-specific Tool instruction and complete JSON Schema. A second omission rejects the evaluation.
 
 With tracing enabled, AML emits `agent.output` for every submission with its call number and `invalid`, `accepted`, or `ignored` status. Payloads are excluded from metadata-only traces and included only for a sink that explicitly enables content capture. See the [structured-output cookbook](/docs/cookbook/structured-output/) for the complete pattern.
 

--- a/apps/website/src/content/docs/docs/reference/primitives/agent.mdx
+++ b/apps/website/src/content/docs/docs/reference/primitives/agent.mdx
@@ -36,6 +36,7 @@ For a live session, replace the deterministic provider with [Codex](/docs/provid
 | `name`        | `string`            | —                                                | Optional diagnostic metadata; non-unique and never included in prompts.                                                      |
 | `permissions` | partial permissions | read-write filesystem, network and shell enabled | Requested native harness controls; an active Sandbox may narrow them.                                                        |
 | `provider`    | `AgentProvider`     | runtime `agentProvider`                          | Provider for this session.                                                                                                   |
+| `schema`      | `AmlModelSchema`    | —                                                | Validates this Agent's result and renders it as canonical JSON text in ordinary composition.                                 |
 | `system`      | `string`            | empty                                            | Fixed system text, placed after runtime system text and before child `<System />` blocks.                                    |
 | `timeoutMs`   | `number`            | —                                                | Positive safe integer that bounds this provider session; caller cancellation and cleanup semantics are described below.      |
 
@@ -47,7 +48,9 @@ For a live session, replace the deterministic provider with [Codex](/docs/provid
 
 AML resolves child `<Agent />` components, text, [`<System />`](/docs/reference/primitives/system/), [`<Skill />`](/docs/reference/primitives/skill/), [`<Tool />`](/docs/reference/primitives/tool/), [`<Mcp />`](/docs/reference/primitives/mcp/), and [`<FollowUp />`](/docs/reference/primitives/follow-up/) descriptors before the provider session begins. Prompt and system fragments are trimmed at the session boundary; ordinary child text is otherwise concatenated without inserted separators.
 
-The provider returns an `AgentResponse`. Normal evaluation contributes its `text` to the surrounding AML value. Component-local [`evaluate()`](/docs/reference/runtime/#component-local-evaluation) can additionally validate a single `<Agent />` result against a Standard Schema. Built-in ACP providers validate submitted candidates during the turn, accept the first valid candidate, and ignore later submissions.
+The provider returns an `AgentResponse`. Normal evaluation contributes its `text` to the surrounding AML value. With `schema`, AML instead validates the structured response and renders the transformed value as canonical JSON text with deterministically ordered object keys. Transformations that produce non-JSON values, including `undefined`, reject because ordinary AML composition is a text channel.
+
+Component-local [`evaluate()`](/docs/reference/runtime/#component-local-evaluation) remains the typed collector: pass its schema as the second argument when TypeScript needs the inferred value. Do not also set the Agent `schema` prop; one Agent has one schema owner.
 
 ## Placement and scope
 
@@ -60,7 +63,7 @@ The provider returns an `AgentResponse`. Normal evaluation contributes its `text
 
 An Agent trace contains one `agent.session` span, one ordered `agent.turn` span for the initial prompt and each [`<FollowUp />`](/docs/reference/primitives/follow-up/), and one `agent.cleanup` span. Built-in ACP providers stream `acp.session.update` events inside the active turn and attach the final ACP stop reason and optional usage to the successful turn end.
 
-One Agent turn is one provider `runTurn()` call and, on the shared ACP path, one ACP `session/prompt` request. It must not be interpreted as one underlying model API call. See [Observability](/docs/observability/#what-an-agent-trace-represents) for the lifecycle tree, content policy, and ACP limitations.
+One Agent turn is one provider `runTurn()` call. It normally maps to one ACP `session/prompt` request, but a schema-bearing final turn may contain one additional repair prompt when the Agent omits the result Tool. It must not be interpreted as one underlying model API call. See [Observability](/docs/observability/#what-an-agent-trace-represents) for the lifecycle tree, content policy, and ACP limitations.
 
 <Aside type="caution" title="Agent permissions are not confinement">
   Native provider permissions are best-effort harness controls. Use a Sandbox provider with an appropriate isolation

--- a/apps/website/src/content/docs/docs/reference/primitives/follow-up.mdx
+++ b/apps/website/src/content/docs/docs/reference/primitives/follow-up.mdx
@@ -35,7 +35,7 @@ const result = await runtime.evaluate(
 - Authored order is preserved.
 - Every turn counts toward `maxTurnsPerAgent`; the default budget is 16 turns including the initial prompt.
 - The same Agent-scoped Tools, MCP servers, model, permissions, Sandbox view, and provider session apply to every turn.
-- When structured output is requested, the schema applies to the final turn.
+- When structured output is requested through the Agent `schema` prop or `evaluate(value, schema)`, the schema applies only to the final authored turn. If that turn omits the result Tool, built-in ACP providers send one schema-bearing repair prompt afterward.
 
 With tracing enabled, AML starts and ends each `agent.turn` around actual execution. A later follow-up cannot appear as started before the preceding turn ends. The initial turn has `kind="initial"`; later turns have `kind="follow-up"`, and all carry a one-based `index`. ACP messages, Tool updates, plans, and usage emitted during that prompt stay ordered inside its turn. See [Observability](/docs/observability/#agent-lifecycle-events).
 

--- a/apps/website/src/content/docs/docs/reference/provider-authoring.mdx
+++ b/apps/website/src/content/docs/docs/reference/provider-authoring.mdx
@@ -89,7 +89,7 @@ If `supportsSandbox()` returns `true`, `run()` must actually launch model-contro
 
 ### ACP profile extension
 
-Use `defineAcpAgentProvider()` when the vendor already exposes an Agent Client Protocol executable. AML's shared ACP adapter owns process launch, one-session turn order, JavaScript Tool and structured-output bridging, immediate candidate validation, first-valid-result selection, submission tracing, MCP descriptors, temporary state, local versus Sandbox execution, abort, cleanup, and portable ACP-boundary telemetry.
+Use `defineAcpAgentProvider()` when the vendor already exposes an Agent Client Protocol executable. AML's shared ACP adapter owns process launch, one-session turn order, JavaScript Tool and structured-output bridging, immediate candidate validation, first-valid-result selection, the one-prompt missing-output repair, submission tracing, MCP descriptors, temporary state, local versus Sandbox execution, abort, cleanup, and portable ACP-boundary telemetry. Profiles may customize the Tool instruction, but they must not fork that lifecycle or recovery policy.
 
 ```ts
 import { defineAcpAgentProvider, type AcpAgentProfile } from "@aml-jsx/sdk"

--- a/apps/website/src/content/docs/docs/reference/runtime.mdx
+++ b/apps/website/src/content/docs/docs/reference/runtime.mdx
@@ -81,6 +81,8 @@ const report = await evaluate(<Agent>Return the report.</Agent>, ReportSchema)
 
 The schema remains application-owned. AML derives the provider-facing JSON Schema from it and retains the authoritative validator. On the shared ACP path, AML validates every `aml_submit_result` candidate immediately so the Agent can correct invalid output in the same turn. The first valid candidate wins; later candidates are ignored. AML still enforces the schema at the final application boundary before returning the value.
 
+Use `<Agent schema={ReportSchema}>` instead when a nested Agent should validate its own boundary and contribute canonical JSON text to the surrounding AML tree. An Agent `schema` prop and the second `evaluate()` argument are alternative schema owners and cannot be combined on the same Agent.
+
 ## Errors and lifecycle events
 
 `EvaluationError` identifies invalid authored AML values and evaluator invariants. Provider failures, schema failures, capability validation, cancellation, and cleanup failures retain their original causes where possible. Catch `EvaluationError` when you specifically need to distinguish an AML authoring/runtime failure from an upstream failure.

--- a/providers/agents/copilot/tests/copilot-agent.test.tsx
+++ b/providers/agents/copilot/tests/copilot-agent.test.tsx
@@ -129,7 +129,7 @@ describe("copilotAgent()", () => {
 
   it("uses Copilot-qualified names for AML JavaScript Tools and structured output", async () => {
     let mcpServerName: string | undefined
-    let prompt = ""
+    const prompts: string[] = []
     const Result = z.object({ status: z.literal("done") })
     const proof = defineTool({
       description: "Return a deterministic proof",
@@ -147,7 +147,7 @@ describe("copilotAgent()", () => {
             mcpServerName = servers[0]?.name
           },
           onPrompt(value) {
-            prompt = value
+            prompts.push(value)
           },
         })
       },
@@ -173,9 +173,13 @@ describe("copilotAgent()", () => {
     ).rejects.toThrow('Agent "copilot"')
 
     expect(mcpServerName).toMatch(/^aml_[a-f0-9]{32}$/)
-    expect(prompt).toContain("<SYSTEM>\nFollow the authored system.\n</SYSTEM>")
-    expect(prompt).toContain(`- copilot_proof: ${mcpServerName}-copilot_proof`)
-    expect(prompt).toContain(`Call the Copilot MCP tool "${mcpServerName}-aml_submit_result" once`)
+    expect(prompts).toHaveLength(2)
+    expect(prompts[0]).toContain("<SYSTEM>\nFollow the authored system.\n</SYSTEM>")
+    expect(prompts[0]).toContain(`- copilot_proof: ${mcpServerName}-copilot_proof`)
+    expect(prompts[0]).toContain(`Call the Copilot MCP tool "${mcpServerName}-aml_submit_result" once`)
+    expect(prompts[1]).toContain("The previous turn ended without submitting a valid structured result.")
+    expect(prompts[1]).toContain(`Call the Copilot MCP tool "${mcpServerName}-aml_submit_result" once`)
+    expect(prompts[1]).toContain('"status"')
   })
 
   it("validates options before launch and forwards arbitrary reasoning effort", async () => {

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -30,6 +30,8 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
   }
 
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
+    const configuration: NonNullable<AcpAgentLaunch["configuration"]>[number][] = []
+    const initialPromptSections: string[] = []
     const tools: Record<string, boolean> = { "*": true }
     const permission: Record<string, "allow" | "deny"> = { "*": "allow" }
     const inheritedPermission: Record<string, "deny"> = {}
@@ -59,12 +61,30 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
       inheritedPermission.websearch = "deny"
     }
 
+    if (context.request.system.length > 0) {
+      initialPromptSections.push(`<SYSTEM>\n${context.request.system}\n</SYSTEM>`)
+    }
+
+    if (context.amlMcpServerName !== undefined && context.request.tools.length > 0) {
+      // OpenCode exposes MCP tools as <server>_<tool>. Name every generated
+      // bridge Tool so the model can reliably address the authored capability.
+      const toolMappings = context.request.tools
+        .map(tool => `- ${tool.name}: ${context.amlMcpServerName}_${tool.name}`)
+        .join("\n")
+      initialPromptSections.push(`AML JavaScript Tools use these OpenCode MCP tool names:\n${toolMappings}`)
+    }
+
     const configuredAgents = configTable(this.#options.config.agent)
     const configuredPermission =
       typeof this.#options.config.permission === "string"
         ? { "*": this.#options.config.permission }
         : (this.#options.config.permission ?? {})
     const model = context.request.model ?? this.#options.model ?? this.#options.config.model
+    if (model !== undefined) {
+      // OpenCode ACP owns the session model after launch. File and environment
+      // config alone leave the session on OpenCode's fallback model.
+      configuration.push({ category: "model", value: model })
+    }
     const config: Config = {
       ...this.#options.config,
       agent: {
@@ -85,19 +105,28 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
     return Object.freeze({
       args: ["acp", "--pure", "--cwd", context.cwd, ...this.#options.args],
       command: this.#options.command,
+      configuration: Object.freeze(configuration),
       env: {
         ...this.#options.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
         OPENCODE_DB: `${context.stateDirectory}/opencode.db`,
         XDG_CACHE_HOME: `${context.stateDirectory}/cache`,
         XDG_CONFIG_HOME: `${context.stateDirectory}/config`,
-        XDG_DATA_HOME: `${context.stateDirectory}/data`,
+        // Callers may stage a request-local login while AML still owns every
+        // other invocation-private OpenCode state directory.
+        XDG_DATA_HOME: this.#options.env.XDG_DATA_HOME ?? `${context.stateDirectory}/data`,
         XDG_STATE_HOME: `${context.stateDirectory}/state`,
       },
-      ...(context.request.system.length === 0
-        ? {}
-        : { initialPromptPrefix: `<SYSTEM>\n${context.request.system}\n</SYSTEM>` }),
+      ...(initialPromptSections.length === 0 ? {} : { initialPromptPrefix: initialPromptSections.join("\n\n") }),
       permissionPolicy: "allow_always",
+      ...(context.amlMcpServerName === undefined || context.request.output === undefined
+        ? {}
+        : {
+            structuredOutputInstruction:
+              `Call the OpenCode MCP tool "${context.amlMcpServerName}_aml_submit_result" once with the final value ` +
+              "in its result field. If the tool returns an error, correct the result and retry the call. " +
+              "After the tool accepts a result, do not call it again. Do not return substitute JSON only as message text.",
+          }),
     })
   }
 }

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -167,10 +167,14 @@ describe("opencodeAgent()", () => {
       )
     ).rejects.toThrow('Agent "opencode"')
 
-    expect(prompts).toHaveLength(1)
+    expect(prompts).toHaveLength(2)
     expect(prompts[0]).toMatch(
       /^<SYSTEM>\nFollow the system\.\n<\/SYSTEM>\n\nAML JavaScript Tools use these OpenCode MCP tool names:\n- read_evidence: aml_[a-f0-9]+_read_evidence\n\nSubmit proof\.\n\nCall the OpenCode MCP tool "aml_[a-f0-9]+_aml_submit_result"/u
     )
+    expect(prompts[1]).toMatch(
+      /^The previous turn ended without submitting a valid structured result\.\n\nCall the OpenCode MCP tool "aml_[a-f0-9]+_aml_submit_result"/u
+    )
+    expect(prompts[1]).toContain('"proof"')
   })
 
   it("maps restrictive Agent permissions into OpenCode's native controls", async () => {

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -1,7 +1,8 @@
-import { agent, methods, ndJsonStream } from "@agentclientprotocol/sdk"
-import { Agent, AmlRuntime, FollowUp, Sandbox, type SandboxProcess } from "@aml-jsx/sdk"
+import { agent, methods, ndJsonStream, type SessionConfigOption } from "@agentclientprotocol/sdk"
+import { Agent, AmlRuntime, defineTool, evaluate, FollowUp, Sandbox, Tool, type SandboxProcess } from "@aml-jsx/sdk"
 import { DeterministicSandboxProvider } from "@aml-jsx/sdk/testing"
 import { describe, expect, it } from "vitest"
+import { z } from "zod"
 
 import { opencodeAgent } from "../src/index.js"
 
@@ -23,7 +24,7 @@ describe("opencodeAgent()", () => {
       args: ["--print-logs"],
       command: "custom-opencode",
       config: { share: "disabled" },
-      env: { PROVIDER_TOKEN: "configured" },
+      env: { PROVIDER_TOKEN: "configured", XDG_DATA_HOME: "/staged/opencode-data" },
       model: "opencode-go/minimax-m3",
     })
 
@@ -45,7 +46,7 @@ describe("opencodeAgent()", () => {
         env: expect.objectContaining({
           OPENCODE_DB: expect.stringMatching(/^\/tmp\/aml-acp-[^/]+\/opencode\.db$/),
           PROVIDER_TOKEN: "configured",
-          XDG_DATA_HOME: expect.stringMatching(/^\/tmp\/aml-acp-/),
+          XDG_DATA_HOME: "/staged/opencode-data",
         }),
       },
     })
@@ -105,6 +106,71 @@ describe("opencodeAgent()", () => {
     )
 
     expect(prompts).toEqual(["Initial"])
+  })
+
+  it("selects the configured model through the ACP session", async () => {
+    const configuredModels: string[] = []
+    const model = "opencode/deepseek-v4-flash"
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn() {
+        return acpFixtureProcess(() => {}, {
+          model,
+          onModel: configuredModel => configuredModels.push(configuredModel),
+        })
+      },
+    })
+
+    await new AmlRuntime({ agentProvider: opencodeAgent({ model }) }).evaluate(
+      <Sandbox provider={sandboxProvider}>
+        <Agent>Initial</Agent>
+      </Sandbox>
+    )
+
+    expect(configuredModels).toEqual([model])
+  })
+
+  it("names generated OpenCode MCP tools in structured turns", async () => {
+    const prompts: string[] = []
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn(command) {
+        if (command === "node") return relayFixtureProcess()
+        return acpFixtureProcess(prompt => prompts.push(prompt))
+      },
+    })
+    const Result = z.object({ proof: z.string() })
+    const readEvidence = defineTool({
+      description: "Read evidence",
+      execute: async () => "evidence",
+      input: z.object({}),
+      name: "read_evidence",
+    })
+
+    async function StructuredResult() {
+      return JSON.stringify(
+        await evaluate(
+          <Agent system="Follow the system.">
+            <Tool use={readEvidence} />
+            Submit proof.
+          </Agent>,
+          Result
+        )
+      )
+    }
+
+    await expect(
+      new AmlRuntime({ agentProvider: opencodeAgent() }).evaluate(
+        <Sandbox provider={sandboxProvider}>
+          <StructuredResult />
+        </Sandbox>
+      )
+    ).rejects.toThrow('Agent "opencode"')
+
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toMatch(
+      /^<SYSTEM>\nFollow the system\.\n<\/SYSTEM>\n\nAML JavaScript Tools use these OpenCode MCP tool names:\n- read_evidence: aml_[a-f0-9]+_read_evidence\n\nSubmit proof\.\n\nCall the OpenCode MCP tool "aml_[a-f0-9]+_aml_submit_result"/u
+    )
   })
 
   it("maps restrictive Agent permissions into OpenCode's native controls", async () => {
@@ -182,15 +248,37 @@ function completedProcess(): Readonly<SandboxProcess> {
   })
 }
 
-function acpFixtureProcess(onPrompt: (prompt: string) => void): Readonly<SandboxProcess> {
+function acpFixtureProcess(
+  onPrompt: (prompt: string) => void,
+  options: { readonly model?: string; readonly onModel?: (value: string) => void } = {}
+): Readonly<SandboxProcess> {
   const clientToAgent = new TransformStream<Uint8Array, Uint8Array>()
   const agentToClient = new TransformStream<Uint8Array, Uint8Array>()
+  const configOptions: SessionConfigOption[] =
+    options.model === undefined
+      ? []
+      : [
+          {
+            category: "model",
+            currentValue: "opencode/big-pickle",
+            id: "model",
+            name: "Model",
+            options: [{ name: options.model, value: options.model }],
+            type: "select",
+          },
+        ]
   const app = agent({ name: "opencode-test" })
     .onRequest(methods.agent.initialize, ({ params }) => ({
-      agentCapabilities: {},
+      agentCapabilities: { mcpCapabilities: { http: true } },
       protocolVersion: params.protocolVersion,
     }))
-    .onRequest(methods.agent.session.new, () => ({ sessionId: "opencode-test-session" }))
+    .onRequest(methods.agent.session.new, () => ({ configOptions, sessionId: "opencode-test-session" }))
+    .onRequest(methods.agent.session.setConfigOption, ({ params }) => {
+      if (params.configId === "model" && typeof params.value === "string") {
+        options.onModel?.(params.value)
+      }
+      return { configOptions }
+    })
     .onRequest(methods.agent.session.prompt, ({ params }) => {
       onPrompt(params.prompt.flatMap(block => (block.type === "text" ? [block.text] : [])).join(""))
       return { stopReason: "end_turn" }
@@ -207,6 +295,38 @@ function acpFixtureProcess(onPrompt: (prompt: string) => void): Readonly<Sandbox
     stdout: agentToClient.readable,
     async wait() {
       await connection.closed
+      return { exitCode: 0 }
+    },
+  })
+}
+
+function relayFixtureProcess(): Readonly<SandboxProcess> {
+  let resolveExited: () => void = () => {}
+  const exited = new Promise<void>(resolve => {
+    resolveExited = resolve
+  })
+  let closed = false
+  let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined
+  const stdout = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stdoutController = controller
+      controller.enqueue(new TextEncoder().encode('{"kind":"ready","port":4567}\n'))
+    },
+  })
+
+  return Object.freeze({
+    id: "opencode-mcp-relay-fixture",
+    async kill() {
+      if (closed) return
+      closed = true
+      stdoutController?.close()
+      resolveExited()
+    },
+    stdin: new WritableStream(),
+    stderr: emptyStream(),
+    stdout,
+    async wait() {
+      await exited
       return { exitCode: 0 }
     },
   })

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -45,6 +45,8 @@ Codex, GitHub Copilot, GLM, OpenCode, and Pi use the same ACP lifecycle on the t
 
 `<Agent timeoutMs={...}>` optionally bounds one provider session after it acquires an execution slot. The value must be a positive safe integer. AML derives a session signal that aborts when either this timeout expires or the enclosing evaluation is cancelled; the earliest cause wins, and nested Agents retain independent scopes. Expiry follows the same provider cancellation path as caller cancellation. AML awaits provider-owned abort and cleanup before settling the Agent, and preserves both the cancellation cause and any later cleanup failure.
 
+`<Agent schema={Result}>` validates that Agent's structured result and contributes canonical JSON text to ordinary AML composition. An authored `<FollowUp>` sequence remains valid: AML asks for structured output only on the final authored turn. Use `evaluate(<Agent>...</Agent>, Result)` instead when component code needs the schema-inferred value.
+
 An unsandboxed `<Script />` runs as a trusted host process from `AmlRuntimeOptions.cwd`, defaulting to `process.cwd()`. Inside an active `<Sandbox />`, it runs only through that Sandbox runtime and never falls back to the host. Its optional portable `cwd` resolves from the runtime cwd on the host or from the active Sandbox root.
 
 The public factory names are `codexAgent()`, `copilotAgent()`, `glmAgent()`, `opencodeAgent()`, and `piAgent()`.

--- a/sdk/src/components/agent/acp-agent-session.ts
+++ b/sdk/src/components/agent/acp-agent-session.ts
@@ -61,6 +61,7 @@ export type AcpSessionConfiguration =
 export interface AcpStructuredOutputController {
   readonly instruction: string
   beginStructuredTurn(): void
+  hasStructuredResult(): boolean
   structuredResult(): unknown
 }
 
@@ -189,16 +190,42 @@ class AcpProviderSession implements AgentProviderSession {
     const prefix = this.#initialPromptPrefix
     this.#initialPromptPrefix = undefined
     let prompt = prefix === undefined ? turn.prompt : `${prefix}\n\n${turn.prompt}`
+    let structuredOutput: AcpStructuredOutputController | undefined
+    let structuredOutputInstruction: string | undefined
 
     if (turn.output !== undefined) {
-      if (this.#structuredOutput === undefined) {
+      structuredOutput = this.#structuredOutput
+
+      if (structuredOutput === undefined) {
         throw new Error("ACP structured turn has no AML submission bridge")
       }
 
-      this.#structuredOutput.beginStructuredTurn()
-      prompt = `${prompt}\n\n${this.#structuredOutputInstruction ?? this.#structuredOutput.instruction}`
+      structuredOutputInstruction = this.#structuredOutputInstruction ?? structuredOutput.instruction
+      structuredOutput.beginStructuredTurn()
+      prompt = `${prompt}\n\n${structuredOutputInstruction}`
     }
 
+    let receivedText = await this.#runPrompt(prompt, context)
+
+    if (turn.output !== undefined && structuredOutput !== undefined && !structuredOutput.hasStructuredResult()) {
+      // Some Agents finish their reasoning turn as text even though the result
+      // Tool is available. Give the retained session one explicit repair turn
+      // with both its provider-specific Tool identity and the output contract.
+      receivedText = await this.#runPrompt(
+        structuredOutputReminder(structuredOutputInstruction ?? structuredOutput.instruction, turn.output.jsonSchema),
+        context
+      )
+    }
+
+    context.signal.throwIfAborted()
+    const text = this.#transformText?.(receivedText, this.#session) ?? receivedText
+    return Object.freeze({
+      ...(structuredOutput === undefined ? {} : { structured: structuredOutput.structuredResult() }),
+      text,
+    })
+  }
+
+  async #runPrompt(prompt: string, context: AgentExecutionContext): Promise<string> {
     const turnAttempt = runAcpPrompt(this.#session, prompt, context)
 
     // A silent Agent process exit would otherwise leave nextUpdate() waiting
@@ -208,13 +235,7 @@ class AcpProviderSession implements AgentProviderSession {
       const detail = stderr.trim().length === 0 ? "" : `: ${stderr.trim()}`
       throw new Error(`ACP Agent process exited with code ${result.exitCode} during a turn${detail}`)
     })
-    const receivedText = await Promise.race([turnAttempt, exited])
-    context.signal.throwIfAborted()
-    const text = this.#transformText?.(receivedText, this.#session) ?? receivedText
-    return Object.freeze({
-      ...(turn.output === undefined ? {} : { structured: this.#structuredOutput?.structuredResult() }),
-      text,
-    })
+    return await Promise.race([turnAttempt, exited])
   }
 
   async abort(): Promise<void> {
@@ -253,6 +274,15 @@ class AcpProviderSession implements AgentProviderSession {
     if (errors.length === 1) throw errors[0]
     if (errors.length > 1) throw new AggregateError(errors, "ACP session cleanup failed")
   }
+}
+
+function structuredOutputReminder(instruction: string, jsonSchema: Readonly<Record<string, unknown>>): string {
+  return [
+    "The previous turn ended without submitting a valid structured result.",
+    instruction,
+    "Call the structured-result Tool now. Do not continue the analysis or answer only with message text.",
+    `The required result must match this JSON Schema:\n${JSON.stringify(jsonSchema, null, 2)}`,
+  ].join("\n\n")
 }
 
 /**

--- a/sdk/src/components/agent/acp-mcp-bridge.ts
+++ b/sdk/src/components/agent/acp-mcp-bridge.ts
@@ -89,6 +89,10 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     this.#acceptStructuredOutput = true
   }
 
+  hasStructuredResult(): boolean {
+    return this.#structuredAccepted
+  }
+
   close(): Promise<void> {
     this.#closePromise ??= this.#close()
     return this.#closePromise

--- a/sdk/src/components/agent/agent-executor.ts
+++ b/sdk/src/components/agent/agent-executor.ts
@@ -7,7 +7,7 @@ import type { AgentMcpServer } from "../mcp/aml-mcp-server.js"
 import type { AgentTool } from "../tool/agent-tool.js"
 import { agentDiagnosticIdentity } from "./agent-diagnostic-identity.js"
 import { AgentExecutionResult } from "./agent-execution-result.js"
-import type { ModelSchema } from "./model-schema.js"
+import { ModelSchema } from "./model-schema.js"
 import type { AgentProps } from "./agent.js"
 import type { AgentProvider } from "./agent-provider.js"
 import { AgentRequestPlan } from "./agent-request-plan.js"
@@ -88,6 +88,20 @@ export class AgentExecutor {
     return explicitProvider === undefined
       ? this.#agentProvider
       : ComponentEvaluationContext.withoutAccess(() => validateAgentProvider(explicitProvider))
+  }
+
+  /**
+   * Selects one schema owner for an Agent before its descendants execute.
+   */
+  outputSchema(
+    props: Readonly<AgentProps>,
+    evaluationSchema: ModelSchema<unknown> | undefined
+  ): ModelSchema<unknown> | undefined {
+    if (props.schema !== undefined && evaluationSchema !== undefined) {
+      throw new EvaluationError("<Agent> schema cannot be combined with evaluate(value, schema)")
+    }
+
+    return props.schema === undefined ? evaluationSchema : new ModelSchema(props.schema)
   }
 
   /**

--- a/sdk/src/components/agent/agent.tsx
+++ b/sdk/src/components/agent/agent.tsx
@@ -1,4 +1,5 @@
 import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
+import type { AmlModelSchema } from "./aml-model-schema.js"
 import type { AgentProvider } from "./agent-provider.js"
 
 /**
@@ -26,6 +27,7 @@ export interface AgentProps {
   readonly name?: string
   readonly permissions?: AgentPermissionOverrides
   readonly provider?: AgentProvider
+  readonly schema?: AmlModelSchema<unknown, unknown>
   readonly system?: string
   readonly timeoutMs?: number
 }

--- a/sdk/src/components/agent/model-schema.ts
+++ b/sdk/src/components/agent/model-schema.ts
@@ -63,4 +63,19 @@ export class ModelSchema<Output> {
 
     return result.value as Output
   }
+
+  /**
+   * Renders a transformed schema result as canonical JSON for AML text channels.
+   */
+  stringify(value: unknown): string {
+    let captured: AmlJsonValue
+
+    try {
+      captured = JsonSnapshot.capture(value, "Transformed Agent structured output")
+    } catch (cause) {
+      throw new TypeError("Transformed Agent structured output cannot be rendered as JSON text", { cause })
+    }
+
+    return JSON.stringify(captured)
+  }
 }

--- a/sdk/src/core/aml-runtime.ts
+++ b/sdk/src/core/aml-runtime.ts
@@ -129,6 +129,7 @@ interface ReleaseFrame {
 }
 
 interface CompleteAgentFrame {
+  readonly collectStructured: boolean
   readonly kind: "complete-agent"
   readonly plan: AgentTarget
   readonly props: Readonly<AgentProps>
@@ -713,7 +714,7 @@ export class AmlRuntime {
           })
           const response = execution.response
 
-          if (frame.schema !== undefined) {
+          if (frame.schema !== undefined && frame.collectStructured) {
             const collector = frame.target.structured
 
             if (collector === undefined) {
@@ -724,6 +725,8 @@ export class AmlRuntime {
             // receives a ModelSchema, including transformed undefined output.
             collector.hasResult = true
             collector.result = response.structured
+          } else if (frame.schema !== undefined) {
+            appendText(frame.target, frame.schema.stringify(response.structured))
           } else {
             appendText(frame.target, response.text)
           }
@@ -805,10 +808,16 @@ export class AmlRuntime {
             const trace = context.createTrace(frame.target.parentSpanId)
             const span = context.startTraceSpan(trace, "agent", "Agent")
             let provider: Readonly<ValidatedAgentProvider> | undefined
+            let schema: ModelSchema<unknown> | undefined
             let sandbox: Readonly<SandboxSession> | undefined
 
             try {
               provider = this.#agentExecutor.validateProps(props)
+              const evaluationSchema =
+                collector !== undefined && frame.target.kind === "text" && frame.target.source === "evaluation"
+                  ? collector.schema
+                  : undefined
+              schema = this.#agentExecutor.outputSchema(props, evaluationSchema)
               sandbox = this.#sandboxEvaluator.forAgent(frame.target.sandbox, props.cwd)
             } catch (error) {
               context.failTraceSpan(span, error)
@@ -840,14 +849,13 @@ export class AmlRuntime {
             activeTraceSpans.push(span)
             frames.push({ kind: "release", value: current })
             frames.push({
+              collectStructured:
+                collector !== undefined && frame.target.kind === "text" && frame.target.source === "evaluation",
               kind: "complete-agent",
               plan,
               props,
               provider,
-              schema:
-                collector !== undefined && frame.target.kind === "text" && frame.target.source === "evaluation"
-                  ? collector.schema
-                  : undefined,
+              schema,
               sandbox,
               span,
               target: frame.target,

--- a/sdk/tests/acp-agent-session.test.ts
+++ b/sdk/tests/acp-agent-session.test.ts
@@ -1,0 +1,157 @@
+import { agent, methods, ndJsonStream } from "@agentclientprotocol/sdk"
+import { describe, expect, it } from "vitest"
+
+import { openAcpSession, type AcpStructuredOutputController } from "../src/components/agent/acp-agent-session.js"
+import { agentObservabilityServices } from "../src/components/agent/agent-observability-services.js"
+import type { SandboxProcess } from "../src/components/sandbox/sandbox-runtime.js"
+import { createAgentExecutionContext } from "../src/testing/create-agent-execution-context.js"
+
+describe("openAcpSession() structured output", () => {
+  it("repairs missing output only after the final authored FollowUp", async () => {
+    const prompts: string[] = []
+    const output = new StructuredOutputFixture()
+    const process = acpProcess(prompt => {
+      prompts.push(prompt)
+      if (prompts.length === 3) output.accept({ proof: "accepted" })
+    })
+    const context = createAgentExecutionContext()
+    const session = await openAcpSession({
+      cwd: "/workspace",
+      observability: agentObservabilityServices(context),
+      process,
+      signal: context.signal,
+      structuredOutput: output,
+      structuredOutputInstruction: 'Call the provider Tool "qualified_submit" with result.',
+    })
+
+    await expect(
+      session.runTurn(
+        {
+          index: 0,
+          isFinal: false,
+          prompt: "Inspect the repository.",
+        },
+        context
+      )
+    ).resolves.toEqual({ text: "" })
+
+    await expect(
+      session.runTurn(
+        {
+          index: 1,
+          isFinal: true,
+          output: {
+            jsonSchema: {
+              additionalProperties: false,
+              properties: { proof: { type: "string" } },
+              required: ["proof"],
+              type: "object",
+            },
+            type: "json",
+          },
+          prompt: "Submit the final finding.",
+        },
+        context
+      )
+    ).resolves.toEqual({ structured: { proof: "accepted" }, text: "" })
+
+    expect(prompts).toHaveLength(3)
+    expect(prompts[0]).toBe("Inspect the repository.")
+    expect(prompts[1]).toBe('Submit the final finding.\n\nCall the provider Tool "qualified_submit" with result.')
+    expect(prompts[2]).toContain("The previous turn ended without submitting a valid structured result.")
+    expect(prompts[2]).toContain('Call the provider Tool "qualified_submit" with result.')
+    expect(prompts[2]).toContain('"required": [\n    "proof"\n  ]')
+    expect(prompts[2]).toContain("Call the structured-result Tool now.")
+
+    await session.close()
+  })
+
+  it("stops after one repair turn when the Agent still omits structured output", async () => {
+    const prompts: string[] = []
+    const output = new StructuredOutputFixture()
+    const process = acpProcess(prompt => prompts.push(prompt))
+    const context = createAgentExecutionContext()
+    const session = await openAcpSession({
+      cwd: "/workspace",
+      observability: agentObservabilityServices(context),
+      process,
+      signal: context.signal,
+      structuredOutput: output,
+    })
+
+    await expect(
+      session.runTurn(
+        {
+          index: 0,
+          isFinal: true,
+          output: { jsonSchema: { type: "string" }, type: "json" },
+          prompt: "Return a string.",
+        },
+        context
+      )
+    ).rejects.toThrow("ACP Agent did not submit a valid structured result")
+    expect(prompts).toHaveLength(2)
+
+    await session.close()
+  })
+})
+
+class StructuredOutputFixture implements AcpStructuredOutputController {
+  readonly instruction = "Call aml_submit_result."
+  #accepted = false
+  #value: unknown
+
+  accept(value: unknown): void {
+    this.#accepted = true
+    this.#value = value
+  }
+
+  beginStructuredTurn(): void {}
+
+  hasStructuredResult(): boolean {
+    return this.#accepted
+  }
+
+  structuredResult(): unknown {
+    if (!this.#accepted) throw new Error("ACP Agent did not submit a valid structured result")
+    return this.#value
+  }
+}
+
+function acpProcess(onPrompt: (prompt: string) => void): Readonly<SandboxProcess> {
+  const clientToAgent = new TransformStream<Uint8Array, Uint8Array>()
+  const agentToClient = new TransformStream<Uint8Array, Uint8Array>()
+  let resolveExited: () => void = () => undefined
+  const exited = new Promise<void>(resolve => {
+    resolveExited = resolve
+  })
+  const app = agent({ name: "session-test" })
+    .onRequest(methods.agent.initialize, ({ params }) => ({
+      protocolVersion: params.protocolVersion,
+    }))
+    .onRequest(methods.agent.session.new, () => ({ sessionId: "session-test" }))
+    .onRequest(methods.agent.session.prompt, ({ params }) => {
+      onPrompt(params.prompt.flatMap(block => (block.type === "text" ? [block.text] : [])).join(""))
+      return { stopReason: "end_turn" }
+    })
+  const connection = app.connect(ndJsonStream(agentToClient.writable, clientToAgent.readable))
+
+  return Object.freeze({
+    id: "session-test",
+    async kill() {
+      connection.close()
+      resolveExited()
+    },
+    stdin: clientToAgent.writable,
+    stderr: emptyStream(),
+    stdout: agentToClient.readable,
+    async wait() {
+      await exited
+      return { exitCode: 0 }
+    },
+  })
+}
+
+function emptyStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({ start: controller => controller.close() })
+}

--- a/sdk/tests/agent-runtime.test.tsx
+++ b/sdk/tests/agent-runtime.test.tsx
@@ -1,9 +1,11 @@
+import { z } from "zod"
 import { describe, expect, expectTypeOf, it } from "vitest"
 
 import { Agent } from "../src/components/agent/agent.js"
 import type { AgentProvider } from "../src/components/agent/agent-provider.js"
 import type { AgentRequest } from "../src/components/agent/agent-request.js"
 import { defineAgentProvider } from "../src/components/agent/define-agent-provider.js"
+import { FollowUp } from "../src/components/follow-up/follow-up.js"
 import { System } from "../src/components/system/system.js"
 import { Sandbox } from "../src/components/sandbox/sandbox.js"
 import type { AmlRenderable } from "../src/core/aml-node.js"
@@ -17,6 +19,69 @@ import { DeterministicAgentProvider } from "../src/testing/deterministic-agent-p
 import { DeterministicSandboxProvider } from "../src/testing/deterministic-sandbox-provider.js"
 
 describe("Agent", () => {
+  it("renders Agent-owned structured output as canonical JSON text", async () => {
+    const Finding = z
+      .object({ evidence: z.array(z.string()), summary: z.string() })
+      .transform(value => ({ summary: value.summary, evidenceCount: value.evidence.length }))
+    const specialist = new DeterministicAgentProvider({
+      name: "specialist",
+      respond(request) {
+        expect(request.prompt).toBe("Inspect.")
+        expect(request.followUps).toEqual(["Submit the final finding."])
+        expect(request.output?.jsonSchema).toMatchObject({
+          properties: { evidence: { type: "array" }, summary: { type: "string" } },
+          type: "object",
+        })
+        return {
+          structured: { evidence: ["line 1", "line 2"], summary: "authorization gap" },
+          text: "ignored specialist prose",
+        }
+      },
+    })
+    const coordinator = new DeterministicAgentProvider({
+      name: "coordinator",
+      respond: request => ({ text: request.prompt }),
+    })
+
+    await expect(
+      new AmlRuntime().evaluate(
+        <Agent provider={coordinator}>
+          Finding:{" "}
+          <Agent provider={specialist} schema={Finding}>
+            Inspect.
+            <FollowUp>Submit the final finding.</FollowUp>
+          </Agent>
+        </Agent>
+      )
+    ).resolves.toBe('Finding: {"evidenceCount":2,"summary":"authorization gap"}')
+  })
+
+  it("attributes invalid Agent-owned output to that Agent boundary", async () => {
+    const Result = z.object({ proof: z.string() })
+    const provider = new DeterministicAgentProvider({
+      respond: () => ({ structured: { proof: 42 }, text: "" }),
+    })
+
+    await expect(
+      new AmlRuntime().evaluate(
+        <Agent name="structured-specialist" provider={provider} schema={Result}>
+          Inspect.
+        </Agent>
+      )
+    ).rejects.toThrow('Agent "deterministic" [name: "structured-specialist"]')
+  })
+
+  it("rejects transformed Agent output that cannot enter a JSON text channel", async () => {
+    const UndefinedResult = z.object({ proof: z.string() }).transform(() => undefined)
+    const provider = new DeterministicAgentProvider({
+      respond: () => ({ structured: { proof: "accepted" }, text: "" }),
+    })
+
+    await expect(
+      new AmlRuntime({ agentProvider: provider }).evaluate(<Agent schema={UndefinedResult}>Inspect.</Agent>)
+    ).rejects.toThrow("Transformed Agent structured output cannot be rendered as JSON text")
+  })
+
   it("uses the runtime provider unless an Agent overrides it", async () => {
     const runtimeProvider = new DeterministicAgentProvider({
       name: "runtime",

--- a/sdk/tests/evaluate-runtime.test.tsx
+++ b/sdk/tests/evaluate-runtime.test.tsx
@@ -452,4 +452,18 @@ describe("component-local evaluate()", () => {
 
     await expect(new AmlRuntime().evaluate(<Workflow />)).resolves.toBe("length:4")
   })
+
+  it("rejects competing Agent-owned and evaluation-owned output schemas", async () => {
+    const provider = new DeterministicAgentProvider()
+
+    async function Workflow() {
+      await evaluate(<Agent schema={ResearchResult}>extract</Agent>, ResearchResult)
+      return "unreachable"
+    }
+
+    await expect(new AmlRuntime({ agentProvider: provider }).evaluate(<Workflow />)).rejects.toThrow(
+      "<Agent> schema cannot be combined with evaluate(value, schema)"
+    )
+    expect(provider.calls).toHaveLength(0)
+  })
 })

--- a/skills/aml-jsx/references/authoring-workflows.md
+++ b/skills/aml-jsx/references/authoring-workflows.md
@@ -67,7 +67,21 @@ async function Review() {
 
 ## Structured output
 
-Pass a Standard Schema-compatible schema as the second argument to `evaluate()`:
+Declare `schema` on a nested Agent when its validated result should continue through ordinary AML text composition:
+
+```tsx
+<Agent provider={Coordinator}>
+  Finding:
+  <Agent provider={OpenCode} schema={Finding}>
+    Inspect the authorization path.
+    <FollowUp>Challenge the evidence, then submit the final finding.</FollowUp>
+  </Agent>
+</Agent>
+```
+
+The validated value renders as canonical JSON text. FollowUps run in authored order, and structured output is requested only on the final authored turn.
+
+Pass the schema as the second argument to `evaluate()` when TypeScript needs its inferred value:
 
 ```tsx
 import { Agent, evaluate } from "@aml-jsx/sdk"
@@ -89,7 +103,7 @@ async function Triage() {
 }
 ```
 
-Use structured output for routing, validation, or application data. Use plain text for prompts and final prose.
+Use one schema owner per Agent: either its `schema` prop for JSON-text composition or `evaluate(value, schema)` for typed collection. Use plain text for prompts and final prose.
 
 ## System content and follow-ups
 


### PR DESCRIPTION
closes #11
closes #22

## Description

Structured Agent results now compose safely through nested AML trees and recover when a coding Agent ends its final turn without calling the result Tool.

## What changed?

- Add an Agent-owned `schema` boundary that validates structured results and contributes canonical JSON text to ordinary AML composition.
- Keep `evaluate(value, schema)` as the typed collection boundary and reject competing schema owners.
- Apply structured output only after all authored FollowUps, then send one shared ACP repair prompt with the qualified Tool instruction and complete JSON Schema when submission is omitted.
- Align OpenCode model selection, staged authentication state, and qualified MCP Tool instructions with the runtime request.
- Record the ownership and recovery decisions in the PRD, normative SPEC, public docs, SDK README, sandbox architecture, and bundled AML skill.

## Verification

- Exercised initial and FollowUp turns, confirming only the final authored turn receives the structured contract and an omitted Tool call gets exactly one repair prompt.
- Asserted nested transformed results enter parent prompts as canonical JSON, while invalid output, non-JSON transformations, competing schemas, and a second omission reject.
- Verified OpenCode and Copilot prompts preserve their qualified result Tool names and that the rendered documentation describes the same lifecycle.

> FollowUps conclude
> Schemas call once more for truth
> Typed branches compose
