### PR TITLE
fix(sdk): verify acp model selection

### DIFF
--- a/apps/website/src/content/docs/docs/providers/agents/opencode.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/opencode.mdx
@@ -26,7 +26,10 @@ The profile starts OpenCode with an ACP server command equivalent to:
 opencode acp --pure --cwd <effective-sandbox-cwd> <your args>
 ```
 
-`command` changes the executable; AML always supplies the ACP arguments before your additional `args`. The profile injects `OPENCODE_CONFIG_CONTENT` with an AML-owned `aml` primary agent, then gives every acquired session private database, cache, config, data, and state directories.
+`command` changes the executable; AML always supplies the ACP arguments before your additional `args`. The profile
+injects `OPENCODE_CONFIG_CONTENT` with an AML-owned `aml` primary agent, then gives every acquired session private
+database, cache, config, and state directories. Its data directory is private by default and may be replaced only
+through an explicit `env.XDG_DATA_HOME` setting.
 
 <Aside type="note" title="Native OpenCode configuration">
   The `config` option is OpenCode's typed `Config` object from `@opencode-ai/sdk/v2`, not an AML-specific arbitrary bag.
@@ -34,7 +37,12 @@ opencode acp --pure --cwd <effective-sandbox-cwd> <your args>
   needed for the session.
 </Aside>
 
-The private XDG directories isolate OpenCode-native user state. OpenCode still loads project rules from `AGENTS.md`, or
+The XDG directories isolate OpenCode-native user state. `XDG_DATA_HOME`, which contains OpenCode's `auth.json`, is
+invocation-private by default. A caller may explicitly point it at a staged data directory through `env`, while AML
+still owns the invocation's session database and every other XDG directory. Prefer a dedicated request-local data
+directory or an environment credential over sharing the operator's complete interactive OpenCode data directory.
+
+OpenCode still loads project rules from `AGENTS.md`, or
 `CLAUDE.md` when no project `AGENTS.md` exists. It can also fall back to `~/.claude/CLAUDE.md` because this profile does
 not replace `HOME`; set `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1` in `env` when that compatibility behavior is unwanted.
 Loaded rules remain OpenCode system instructions. AML-authored System content is delivered separately as a first-turn prelude.
@@ -68,6 +76,10 @@ opencode auth list
 ```
 
 `opencode auth login` stores provider credentials in OpenCode's own data directory. `opencode auth list` also reports provider credentials discovered through environment variables. AML does not copy those credentials into a Workspace or infer which model provider you intended.
+
+For an isolated invocation, pass the provider credential through `env` or stage the required OpenCode data into a
+dedicated directory and set `env.XDG_DATA_HOME` to it. `OPENCODE_DB` remains invocation-private even when the data
+directory is explicitly staged, so the Agent does not import or persist interactive session history.
 
 The AML repository currently pins `opencode-ai@1.18.18` for its integration toolchain and `@opencode-ai/sdk@1.18.5` for the typed provider configuration. These versions are the repository's verification baseline, not a claim that every newer OpenCode release is compatible. Re-run the provider integration path when changing either side.
 
@@ -199,11 +211,14 @@ For each acquired session AML sets:
 OPENCODE_DB       <state>/opencode.db
 XDG_CACHE_HOME    <state>/cache
 XDG_CONFIG_HOME   <state>/config
-XDG_DATA_HOME     <state>/data
+XDG_DATA_HOME     <state>/data (default) or an explicit env.XDG_DATA_HOME
 XDG_STATE_HOME    <state>/state
 ```
 
-The profile creates the launch configuration after AML has resolved the effective Sandbox cwd and capabilities. AML then starts the ACP session, streams turns, validates the response, and releases provider-owned state through the shared lifecycle. Do not persist these temporary directories as a Workspace artifact unless you intentionally want OpenCode session state in your application.
+The profile creates the launch configuration after AML has resolved the effective Sandbox cwd and capabilities.
+`OPENCODE_DB`, cache, config, and state always remain invocation-owned. AML then starts the ACP session, streams turns,
+validates the response, and releases provider-owned state through the shared lifecycle. Do not persist these temporary
+directories as a Workspace artifact unless you intentionally want OpenCode session state in your application.
 
 ## Failure modes and troubleshooting
 

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -83,7 +83,7 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
     if (model !== undefined) {
       // OpenCode ACP owns the session model after launch. File and environment
       // config alone leave the session on OpenCode's fallback model.
-      configuration.push({ category: "model", value: model })
+      configuration.push({ id: "model", value: model })
     }
     const config: Config = {
       ...this.#options.config,

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -110,12 +110,14 @@ describe("opencodeAgent()", () => {
 
   it("selects the configured model through the ACP session", async () => {
     const configuredModels: string[] = []
+    const fallbackModel = "opencode/big-pickle"
     const model = "opencode/deepseek-v4-flash"
     const sandboxProvider = new DeterministicSandboxProvider({
       exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
       spawn() {
         return acpFixtureProcess(() => {}, {
-          model,
+          advertisedModels: [fallbackModel, model],
+          currentModel: fallbackModel,
           onModel: configuredModel => configuredModels.push(configuredModel),
         })
       },
@@ -128,6 +130,58 @@ describe("opencodeAgent()", () => {
     )
 
     expect(configuredModels).toEqual([model])
+  })
+
+  it("rejects a configured model that the ACP Agent does not advertise", async () => {
+    const prompts: string[] = []
+    const model = "opencode/deepseek-v4-flash"
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn() {
+        return acpFixtureProcess(prompt => prompts.push(prompt), {
+          advertisedModels: ["opencode/big-pickle"],
+          currentModel: "opencode/big-pickle",
+        })
+      },
+    })
+
+    await expect(
+      new AmlRuntime({ agentProvider: opencodeAgent({ model }) }).evaluate(
+        <Sandbox provider={sandboxProvider}>
+          <Agent>Initial</Agent>
+        </Sandbox>
+      )
+    ).rejects.toMatchObject({
+      cause: { message: `ACP session configuration "model" does not advertise value "${model}"` },
+    })
+    expect(prompts).toEqual([])
+  })
+
+  it("rejects an ACP Agent that does not apply the configured model", async () => {
+    const prompts: string[] = []
+    const fallbackModel = "opencode/big-pickle"
+    const model = "opencode/deepseek-v4-flash"
+    const sandboxProvider = new DeterministicSandboxProvider({
+      exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
+      spawn() {
+        return acpFixtureProcess(prompt => prompts.push(prompt), {
+          advertisedModels: [fallbackModel, model],
+          applyModel: false,
+          currentModel: fallbackModel,
+        })
+      },
+    })
+
+    await expect(
+      new AmlRuntime({ agentProvider: opencodeAgent({ model }) }).evaluate(
+        <Sandbox provider={sandboxProvider}>
+          <Agent>Initial</Agent>
+        </Sandbox>
+      )
+    ).rejects.toMatchObject({
+      cause: { message: `ACP session configuration "model" did not apply value "${model}"` },
+    })
+    expect(prompts).toEqual([])
   })
 
   it("names generated OpenCode MCP tools in structured turns", async () => {
@@ -254,20 +308,25 @@ function completedProcess(): Readonly<SandboxProcess> {
 
 function acpFixtureProcess(
   onPrompt: (prompt: string) => void,
-  options: { readonly model?: string; readonly onModel?: (value: string) => void } = {}
+  options: {
+    readonly advertisedModels?: readonly string[]
+    readonly applyModel?: boolean
+    readonly currentModel?: string
+    readonly onModel?: (value: string) => void
+  } = {}
 ): Readonly<SandboxProcess> {
   const clientToAgent = new TransformStream<Uint8Array, Uint8Array>()
   const agentToClient = new TransformStream<Uint8Array, Uint8Array>()
-  const configOptions: SessionConfigOption[] =
-    options.model === undefined
+  let currentModel = options.currentModel
+  const configOptions = (): SessionConfigOption[] =>
+    options.advertisedModels === undefined
       ? []
       : [
           {
-            category: "model",
-            currentValue: "opencode/big-pickle",
+            currentValue: currentModel ?? options.advertisedModels[0] ?? "opencode/big-pickle",
             id: "model",
             name: "Model",
-            options: [{ name: options.model, value: options.model }],
+            options: options.advertisedModels.map(model => ({ name: model, value: model })),
             type: "select",
           },
         ]
@@ -276,12 +335,16 @@ function acpFixtureProcess(
       agentCapabilities: { mcpCapabilities: { http: true } },
       protocolVersion: params.protocolVersion,
     }))
-    .onRequest(methods.agent.session.new, () => ({ configOptions, sessionId: "opencode-test-session" }))
+    .onRequest(methods.agent.session.new, () => ({
+      configOptions: configOptions(),
+      sessionId: "opencode-test-session",
+    }))
     .onRequest(methods.agent.session.setConfigOption, ({ params }) => {
       if (params.configId === "model" && typeof params.value === "string") {
+        if (options.applyModel !== false) currentModel = params.value
         options.onModel?.(params.value)
       }
-      return { configOptions }
+      return { configOptions: configOptions() }
     })
     .onRequest(methods.agent.session.prompt, ({ params }) => {
       onPrompt(params.prompt.flatMap(block => (block.type === "text" ? [block.text] : [])).join(""))

--- a/sdk/src/components/agent/acp-agent-session.ts
+++ b/sdk/src/components/agent/acp-agent-session.ts
@@ -378,6 +378,13 @@ async function configureSession(
       { cancellationSignal: signal }
     )
     available = response.configOptions
+
+    // A successful update must report the selected value. Do not continue on
+    // a provider fallback after the caller requested an explicit option.
+    const applied = available.find(candidate => candidate.id === option.id)
+    if (applied?.currentValue !== configuration.value) {
+      throw new Error(`ACP session configuration "${option.id}" did not apply value "${configuration.value}"`)
+    }
   }
 }
 


### PR DESCRIPTION
related to #23

## Description

Strengthens the OpenCode model-selection fix from d1c9a0f so AML targets OpenCode's stable ACP model option ID and refuses to prompt unless the session reports the requested model as active.

## What changed?

- select OpenCode's ACP model option by stable model ID instead of optional semantic category
- fail closed when an ACP Agent omits or does not apply the requested session configuration
- cover unavailable and ignored model selections without allowing a prompt
- clarify private OpenCode database/XDG state and explicit staged-auth behavior

## Verification

- Reproduced OpenCode 1.18.18's unauthenticated fallback to opencode/big-pickle, then confirmed AML rejects the unavailable requested model before prompting.
- Exercised successful, unadvertised, and stale model-option responses through the provider boundary.
- Confirmed the shared ACP change remains compatible with the Pi profile.
- Built the OpenCode provider docs and verified the generated page.

> Stable model set
> Private state stays contained
> Fallbacks cannot hide