### PR TITLE
feat(sdk): add explicit Parallel boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ AML tree
   └─ release resources and return the final output
 ```
 
-Ordinary JSX children resolve in authored order. Independent work becomes concurrent only when the component explicitly starts it with JavaScript primitives such as `Promise.all()`.
+Ordinary JSX children resolve in authored order. Wrap independent AML branches in `<Parallel>` when their text should
+flow directly into the surrounding tree. Component code can still use `Promise.all(evaluate(...))` when it needs named
+or typed branch values.
 
 ## Example
 
@@ -45,7 +47,7 @@ Then compose ordinary async components, Agents, and typed JavaScript Tools:
 ```tsx
 import { readFile } from "node:fs/promises"
 
-import { Agent, AmlRuntime, createConsoleTracer, defineTool, evaluate, opencodeAgent, Tool } from "@aml-jsx/sdk"
+import { Agent, AmlRuntime, createConsoleTracer, defineTool, opencodeAgent, Parallel, Tool } from "@aml-jsx/sdk"
 import { z } from "zod"
 
 const OpenCode = opencodeAgent({})
@@ -57,28 +59,37 @@ const ReadSource = defineTool({
   execute: async ({ path }) => await readFile(path, "utf8"),
 })
 
-async function Review() {
-  const [correctness, maintainability] = await Promise.all([
-    evaluate(
+function CorrectnessLane() {
+  return (
+    <>
+      Correctness:
       <Agent provider={OpenCode} system="Find concrete correctness defects.">
         <Tool use={ReadSource} />
         Review src/index.ts.
       </Agent>
-    ),
-    evaluate(
+    </>
+  )
+}
+
+function MaintainabilityLane() {
+  return (
+    <>
+      Maintainability:
       <Agent provider={OpenCode} system="Find proportionate maintainability improvements.">
         <Tool use={ReadSource} />
         Review src/index.ts.
       </Agent>
-    ),
-  ])
+    </>
+  )
+}
 
+function Review() {
   return (
     <Agent provider={OpenCode} system="Synthesize evidence without inventing findings.">
-      Correctness:
-      {correctness}
-      Maintainability:
-      {maintainability}
+      <Parallel>
+        <CorrectnessLane />
+        <MaintainabilityLane />
+      </Parallel>
     </Agent>
   )
 }
@@ -120,6 +131,7 @@ workflows with `@aml-jsx/sdk`.
 | Primitive     | Purpose                                                                                                              |
 | ------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `<Agent>`     | Runs one Agent session and optionally validates its result with an Agent-owned `schema`.                             |
+| `<Parallel>`  | Evaluates independent AML branches concurrently, then contributes their text in authored order.                      |
 | `<System>`    | Adds resolved content to the owning Agent's system prompt. Multiple System blocks are joined in authored order.      |
 | `<Tool>`      | Grants the owning Agent a JavaScript Tool created with `defineTool()`.                                               |
 | `<Skill>`     | Adds reusable inline or local-file instructions to the owning Agent.                                                 |
@@ -359,7 +371,7 @@ docker compose down
 
 Matrix smoke files use a dedicated Vitest configuration and stay outside default unit tests. Omitting both matrix filters runs every registered Agent against every registered Sandbox. npm requires the `--` separator before smoke-runner options.
 
-The manual kitchen-sink smoke defaults to `--agent opencode --sandbox modal --workspace r2 --mcp context7`. It accepts any registered Agent or Sandbox, plus `local | r2` Workspaces and `context7 | none` MCP selection. The workflow exercises all eleven stable primitives, then reacquires the saved Workspace and verifies the persisted files. Run `npm run smoke:kitchen-sink -- --help` for the current selections. Context7 supports anonymous testing; `CONTEXT7_API_KEY` raises its rate limit when configured.
+The manual kitchen-sink smoke defaults to `--agent opencode --sandbox modal --workspace r2 --mcp context7`. It accepts any registered Agent or Sandbox, plus `local | r2` Workspaces and `context7 | none` MCP selection. The workflow exercises all twelve stable primitives, then reacquires the saved Workspace and verifies the persisted files. Run `npm run smoke:kitchen-sink -- --help` for the current selections. Context7 supports anonymous testing; `CONTEXT7_API_KEY` raises its rate limit when configured.
 
 The smoke runners load the repository's untracked `.env`. Codex, OpenCode, and Pi use `OPENAI_API_KEY` or `AML_CODEX_API_KEY`; `AML_CODEX_MODEL`, `AML_OPENCODE_MODEL`, and `AML_PI_MODEL` may override their models. Copilot uses `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` in that order and defaults to `gpt-5-mini`; `AML_COPILOT_GITHUB_TOKEN` and `AML_COPILOT_MODEL` are optional smoke-only overrides. GLM uses `Z_AI_API_KEY` or `AML_ZAI_API_KEY` and defaults to `glm-5.3`; `AML_GLM_MODEL` may override its model. Daytona uses `DAYTONA_API_KEY`. Modal uses the repository-local `MODAL_API_KEY` and `MODAL_API_SECRET` names as `tokenId` and `tokenSecret`; Modal's own ambient credential names remain `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`. The R2 Workspace accepts `R2_BUCKET`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`, with the existing `AML_S3_*` aliases. These environment names configure only the repository's smoke CLI. Applications configure providers through their native factory options and runtime environment.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -159,11 +159,17 @@ AML:
 5. runs the parent Agent last
 6. returns the parent Agent's final text
 
-AML evaluates JSX siblings from left to right. Independent work can run concurrently through ordinary JavaScript:
+AML evaluates JSX siblings from left to right. Independent text-producing branches use an explicit `<Parallel>`
+boundary:
 
 ```tsx
-const [review, audit] = await Promise.all([evaluate(<Reviewer />, ReviewResult), evaluate(<Auditor />, AuditResult)])
+<Parallel>
+  <Reviewer />
+  <Auditor />
+</Parallel>
 ```
+
+Component code may instead use `Promise.all(evaluate(...))` when it needs named or typed branch values.
 
 Implicit sibling concurrency is outside the normative evaluation model. Parent/child dependencies remain post-order.
 
@@ -214,6 +220,7 @@ AML cannot automatically roll back arbitrary effects already performed by an Age
 | `<Fragment>` / `<>`                | Group authored siblings                                              | Ordered child results      |
 | `AmlRuntime`                       | Own one complete evaluation                                          | Final string               |
 | `<Agent>`                          | Execute one Agent boundary                                           | Final text                 |
+| `<Parallel>`                       | Evaluate independent AML branches concurrently                       | Ordered branch text        |
 | `<System>`                         | Contribute resolved text to an Agent's system prompt                 | System descriptor          |
 | `defineAgentProvider()`            | Define an Agent harness adapter                                      | `AgentProvider`            |
 | `<Tool>`                           | Grant a JavaScript capability                                        | Tool descriptor            |
@@ -239,18 +246,18 @@ AML cannot automatically roll back arbitrary effects already performed by an Age
 
 The normative surface is delivered in phases so the public API grows only after each earlier boundary has deterministic proof.
 
-| Phase                  | Surface                                                        | Purpose                                                                               |
-| ---------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Foundation             | JSX values, Fragments, async components, `AmlRuntime`          | Prove single-invocation asynchronous evaluation                                       |
-| MVP 1                  | `<Agent>`, `<System>`, `defineAgentProvider()`                 | Establish the provider-neutral execution and message-channel boundary                 |
-| MVP 2                  | `<Tool>`, `defineTool()`                                       | Add scoped JavaScript capabilities                                                    |
-| MVP 3                  | `<Skill>`                                                      | Add reusable instruction resolution                                                   |
-| MVP 4                  | `<Sandbox>`, `defineSandboxProvider()`                         | Add ephemeral execution scope                                                         |
-| MVP 5                  | `<Workspace>`, `defineWorkspaceProvider()`                     | Add durable filesystem scope and complete the MVP                                     |
-| Post-MVP capabilities  | `<Mcp>`, `defineMcpServer()`                                   | Attach MCP servers without making the SDK own an Agent harness                        |
-| Filesystem composition | `<File>`, `<Script>`                                           | Materialize resolved text and run explicit commands on the host or in resource scopes |
-| Post-MVP orchestration | `evaluate()`, structured output, `<FollowUp>`; draft: `<Loop>` | Add richer dataflow and same-session or iterative execution                           |
-| Draft late surface     | `createContext()`, `useContext()`, `<Context.Provider>`        | Add immutable dependency scope only after the execution and resource model is stable  |
+| Phase                  | Surface                                                                      | Purpose                                                                               |
+| ---------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Foundation             | JSX values, Fragments, async components, `AmlRuntime`                        | Prove single-invocation asynchronous evaluation                                       |
+| MVP 1                  | `<Agent>`, `<System>`, `defineAgentProvider()`                               | Establish the provider-neutral execution and message-channel boundary                 |
+| MVP 2                  | `<Tool>`, `defineTool()`                                                     | Add scoped JavaScript capabilities                                                    |
+| MVP 3                  | `<Skill>`                                                                    | Add reusable instruction resolution                                                   |
+| MVP 4                  | `<Sandbox>`, `defineSandboxProvider()`                                       | Add ephemeral execution scope                                                         |
+| MVP 5                  | `<Workspace>`, `defineWorkspaceProvider()`                                   | Add durable filesystem scope and complete the MVP                                     |
+| Post-MVP capabilities  | `<Mcp>`, `defineMcpServer()`                                                 | Attach MCP servers without making the SDK own an Agent harness                        |
+| Filesystem composition | `<File>`, `<Script>`                                                         | Materialize resolved text and run explicit commands on the host or in resource scopes |
+| Post-MVP orchestration | `evaluate()`, structured output, `<Parallel>`, `<FollowUp>`; draft: `<Loop>` | Add richer dataflow, explicit concurrency, and same-session or iterative execution    |
+| Draft late surface     | `createContext()`, `useContext()`, `<Context.Provider>`                      | Add immutable dependency scope only after the execution and resource model is stable  |
 
 This is a delivery order, not a hierarchy of importance. Later primitives remain normative desired state, but they must not shape earlier implementations beyond the explicit extension points in their contracts.
 
@@ -468,7 +475,8 @@ A child Agent is deterministic authored composition:
 
 The child Agents finish before the parent Agent session begins. Their final texts are inserted into the parent input at their authored positions. They do not become distinct provider message roles.
 
-AML evaluates these siblings left to right. Explicit `Promise.all(evaluate(...))` is the normative parallel form.
+AML evaluates these siblings left to right. Wrap independent text-producing branches in `<Parallel>`; use
+`Promise.all(evaluate(...))` when component code needs to inspect or transform the individual results.
 
 ### 5.4 Agent result
 
@@ -935,19 +943,46 @@ Nested calls share the root evaluation's:
 
 ### 10.2 Parallel dataflow
 
-Independent calls may be started together:
+`<Parallel>` is a normal AML component built on component-local `evaluate()`. Each recursively flattened child array
+entry becomes an independent branch; empty values are ignored. A Fragment remains one branch, so its children keep
+their ordinary sequential semantics.
 
 ```tsx
-const [review, audit] = await Promise.all([evaluate(<Reviewer />, ReviewResult), evaluate(<Auditor />, AuditResult)])
+<Agent>
+  <Parallel>
+    <Reviewer />
+    {auditors.map(auditor => (
+      <Auditor kind={auditor} />
+    ))}
+  </Parallel>
+  Synthesize the completed reviews.
+</Agent>
 ```
 
-`maxConcurrentAgents` limits active Agent sessions. `Promise.all()` preserves result array order even when Agents finish out of order.
+Branches start together and collect into isolated text targets while active. `<Parallel>` waits for every branch to
+settle, including owned cleanup, and contributes successful text in authored branch order rather than completion order.
+An Agent with a `schema` prop contributes its validated canonical JSON text through the same composition channel.
+`<Parallel>` itself remains a text boundary; a schema-bearing `evaluate(<Parallel>...</Parallel>, schema)` does not turn
+several branch Agents into one structured root result.
+
+If any branch rejects, `<Parallel>` throws `ParallelError` only after every branch has settled. Its `failures` array is
+ordered by authored branch position and contains `{ branchIndex, cause }`, where `branchIndex` is zero-based and `cause`
+is that branch's rejection. One and multiple failures use the same error type. `<Parallel>` does not expose partial
+results, retry branches, cancel healthy siblings after a failure, or roll back Tool, filesystem, network, or other side
+effects that completed before rejection.
+
+Direct `<System>`, `<Tool>`, and other Agent-owned descriptors inside `<Parallel>` do not mutate an Agent surrounding the
+component. Put those descriptors inside the branch's own `<Agent>`.
+
+`maxConcurrentAgents` limits active Agent sessions inside `<Parallel>`. The component adds no independent concurrency
+prop or scheduler; non-Agent branch work starts with ordinary JavaScript promise concurrency.
 
 The scheduler belongs to one evaluation domain. An Agent resolves its authored children, capabilities, Sandbox view, and structured-output contract before requesting a slot. AML reserves its Agent-call budget and then queues the complete provider call in ready order. A slot is held until `AgentProvider.run()` settles, including any provider-owned session and capability cleanup performed before that Promise resolves.
 
 `maxConcurrentAgents: 0` disables the concurrency limit. A positive value is the maximum number of provider calls active in that evaluation; separate root evaluations have separate schedulers. Aborting the evaluation propagates the caller's signal to active providers, rejects queued Agents with the caller's cancellation reason, and prevents those queued providers from starting. One Agent failure does not implicitly abort independent sibling work that the application already started.
 
-Use `Promise.allSettled()` only when partial failure is an explicit application decision. AML itself does not silently convert Agent failures into partial results.
+Component code may still start `Promise.all(evaluate(...))` when it needs named or schema-inferred values rather than
+ordered text composition. Use `Promise.allSettled()` only when partial failure is an explicit application decision.
 
 ## 11. Scoped context (Draft)
 

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -207,6 +207,7 @@ export default defineConfig({
               items: [
                 { label: "Primitives overview", slug: "docs/reference/primitives" },
                 { label: "<Agent />", slug: "docs/reference/primitives/agent" },
+                { label: "<Parallel />", slug: "docs/reference/primitives/parallel" },
                 { label: "<System />", slug: "docs/reference/primitives/system" },
                 { label: "<Tool />", slug: "docs/reference/primitives/tool" },
                 { label: "<Mcp />", slug: "docs/reference/primitives/mcp" },

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -39,7 +39,10 @@ Use these primary documentation destinations:
 
 AML gives JSX a job unrelated to user interfaces: an AML tree describes executable dependencies between Agents, prompts, capabilities, Sandboxes, and durable Workspaces. `AmlRuntime` resolves that tree from the leaves upward, passes child results into parent prompts at their authored positions, and releases acquired resources in reverse order.
 
-AML is not React, a visual workflow builder, or a replacement for TypeScript control flow. Conditions, functions, promises, loops, and explicit `Promise.all()` calls remain ordinary TypeScript. JSX children resolve in authored order; sibling JSX does not imply concurrency.
+AML is not React, a visual workflow builder, or a replacement for TypeScript control flow. Conditions, functions,
+promises, loops, and typed data collection remain ordinary TypeScript. JSX children resolve in authored order; sibling
+JSX does not imply concurrency. `<Parallel>` explicitly marks independent text-producing branches, while
+`Promise.all(evaluate(...))` remains available when component code needs individual results.
 
 The library separates three provider responsibilities:
 

--- a/apps/website/src/components/marketing/HeroSection.astro
+++ b/apps/website/src/components/marketing/HeroSection.astro
@@ -103,7 +103,7 @@ import { withBase } from "../../config/site.js"
           class="absolute -right-3 top-20 hidden rounded-lg border border-line bg-surface px-3 py-1.5 font-mono text-[11px] text-ink-soft shadow-md sm:block"
           data-float="2"
         >
-          Promise.all(<span class="text-signal">gatherers</span>)
+          &lt;Parallel&gt;<span class="text-signal">gatherers</span>&lt;/Parallel&gt;
         </div>
         <!-- The elevator pitch stays visible on mobile: it is the first concrete glimpse of AML syntax. -->
         <div

--- a/apps/website/src/components/marketing/HowItWorksSection.astro
+++ b/apps/website/src/components/marketing/HowItWorksSection.astro
@@ -2,28 +2,29 @@
 import { withBase } from "../../config/site"
 import { highlightTsx } from "../../highlight"
 
-const source = `import { Agent, evaluate, System, Tool } from "@aml-jsx/sdk"
+const source = `import { Agent, Parallel, System, Tool } from "@aml-jsx/sdk"
 
-async function Review() {
-  const [correctness, maintainability] = await Promise.all([
-    evaluate(
-      <Agent provider={OpenCode}>
-        <Tool use={ReadSource} />
-        Review src/index.ts for correctness defects.
-      </Agent>,
-    ),
-    evaluate(
-      <Agent provider={OpenCode}>
-        Review src/index.ts for maintainability issues.
-      </Agent>,
-    ),
-  ])
+function CorrectnessLane() {
+  return <Agent provider={OpenCode}>
+    <Tool use={ReadSource} />
+    Review src/index.ts for correctness defects.
+  </Agent>
+}
 
+function MaintainabilityLane() {
+  return <Agent provider={OpenCode}>
+    Review src/index.ts for maintainability issues.
+  </Agent>
+}
+
+function Review() {
   return (
     <Agent provider={OpenCode}>
       <System>Synthesize evidence without inventing findings.</System>
-      Correctness: {correctness}
-      Maintainability: {maintainability}
+      <Parallel>
+        <CorrectnessLane />
+        <MaintainabilityLane />
+      </Parallel>
       Produce the final review.
     </Agent>
   )
@@ -44,7 +45,7 @@ const highlightedSource = await highlightTsx(source)
         </h2>
         <p class="reveal mt-5 text-[15px] leading-relaxed text-ink-soft [--reveal-delay:120ms]">
           AML resolves every value before the boundary that consumes it. JSX describes the dependency structure;
-          ordinary TypeScript still owns branching, concurrency, and data flow.
+          ordinary TypeScript owns branching and data flow, while <code>&lt;Parallel&gt;</code> marks independent work.
         </p>
         <div class="reveal mt-7 flex flex-wrap gap-x-6 gap-y-3 [--reveal-delay:160ms]">
           <a

--- a/apps/website/src/components/marketing/ReferenceSection.astro
+++ b/apps/website/src/components/marketing/ReferenceSection.astro
@@ -9,8 +9,8 @@ import { withBase } from "../../config/site"
       Small enough to learn in one sitting
     </h2>
     <p class="reveal mt-5 text-[15px] leading-relaxed text-ink-soft [--reveal-delay:120ms]">
-      Eleven primitives and a focused set of runtime APIs. Everything else is ordinary JavaScript — control flow,
-      concurrency, and data flow included.
+      Twelve primitives and a focused set of runtime APIs. Everything else is ordinary JavaScript — control flow and
+      data transformation included.
     </p>
     <a
       href={withBase("docs/reference/primitives/")}

--- a/apps/website/src/concepts.ts
+++ b/apps/website/src/concepts.ts
@@ -61,22 +61,27 @@ return <Agent>Prepare the standup from: {synthesis}</Agent>`,
     id: "parallel-child-agents",
     group: "Concepts",
     name: "Parallel child Agents",
-    signature: "Promise.all([evaluate(…), evaluate(…)])",
+    signature: "<Parallel>…</Parallel>",
     description:
-      "A parent <Agent /> can depend on several child <Agent /> components. Start the children together with Promise.all(); AML waits for both outputs, resolves the parent's <System /> and prompt content, and only then opens the parent session.",
-    note: "Concurrency is explicit JavaScript. The parent provider receives one complete request containing the resolved <System /> content, prompt, and both child outputs.",
+      "A parent <Agent /> can depend on several independent child branches. <Parallel> starts them together, preserves authored output order, and waits for every branch before the parent session opens.",
+    note: "The runtime's Agent scheduler remains authoritative. One failed branch does not interrupt healthy siblings, and ParallelError reports every failed authored index after cleanup.",
     file: "concepts/parallel-child-agents.tsx",
-    code: `async function Review() {
-  const [security, performance] = await Promise.all([
-    evaluate(<Agent provider={Codex}>Review security.</Agent>),
-    evaluate(<Agent provider={Codex}>Review performance.</Agent>),
-  ])
+    code: `function SecurityLane() {
+  return <>Security: <Agent provider={Codex}>Review security.</Agent></>
+}
 
+function PerformanceLane() {
+  return <>Performance: <Agent provider={Codex}>Review performance.</Agent></>
+}
+
+function Review() {
   return (
     <Agent provider={Codex}>
       <System>Synthesize the evidence. Invent nothing.</System>
-      Security review: {security}
-      Performance review: {performance}
+      <Parallel>
+        <SecurityLane />
+        <PerformanceLane />
+      </Parallel>
       Produce the final review.
     </Agent>
   )
@@ -133,6 +138,24 @@ const [codexReview, openCodeReview] = await Promise.all([
     code: `<Agent provider={OpenCode} system="Find concrete correctness defects.">
   <Tool use={ReadSource} />
   Review src/index.ts.
+</Agent>`,
+  },
+  {
+    id: "parallel",
+    group: "Components",
+    name: "<Parallel />",
+    docsPath: "docs/reference/primitives/parallel/",
+    signature: "<Parallel>…</Parallel>",
+    description:
+      "Evaluates independent AML branches concurrently, waits for all branch cleanup, and contributes successful text in authored order. Failures surface together as ParallelError.",
+    note: "maxConcurrentAgents still bounds provider calls. <Parallel /> adds no retry, fail-fast cancellation, partial-result, or transactional side-effect policy.",
+    file: "parallel.tsx",
+    code: `<Agent provider={Coordinator}>
+  <Parallel>
+    <Agent provider={Reviewer}>Review correctness.</Agent>
+    <Agent provider={Auditor}>Review security.</Agent>
+  </Parallel>
+  Synthesize both reports.
 </Agent>`,
   },
   {

--- a/apps/website/src/content/docs/docs/ast.mdx
+++ b/apps/website/src/content/docs/docs/ast.mdx
@@ -63,7 +63,7 @@ Unknown objects, DOM-like intrinsic elements, cyclic arrays, and cyclic nodes ar
 
 <Aside type="note" title="Fragments are grouping, not scheduling">
   A fragment adds no prompt text and no provider lifecycle. It also does not create implicit concurrency. Use
-  `Promise.all()` when work may safely overlap.
+  [`<Parallel>`](/docs/reference/primitives/parallel/) when independent text-producing branches may safely overlap.
 </Aside>
 
 ## Runtime-owned primitive nodes
@@ -81,6 +81,10 @@ Built-in primitive components are marked for special evaluation. They are not or
 | [`<>…</>`](/docs/reference/primitives/fragment/)                                                                                                                                                                                                            | Stable | JSX runtime         | Groups authored values without adding another boundary.                        |
 
 Placement is part of the contract. For example, `<Tool />` and `<Mcp />` are valid only inside `<Agent />`, while `<File />` requires `<Workspace />` and cannot be nested inside `<Sandbox />`. `<Script />` may execute on the host without a Sandbox; an enclosing Sandbox changes its execution location.
+
+`<Parallel>` is intentionally different from the runtime-owned nodes above: it is a normal exported function component
+built on component-local `evaluate()`. That existing boundary supplies inherited scopes, limits, cancellation, tracing,
+and cleanup joining without adding a second evaluator primitive.
 
 ## Post-order consumers versus lexical scopes
 

--- a/apps/website/src/content/docs/docs/concepts.mdx
+++ b/apps/website/src/content/docs/docs/concepts.mdx
@@ -135,27 +135,29 @@ JavaScript evaluates ordinary expressions in authored order. If two JSX values a
 
 ### Explicit concurrency
 
-AML does not infer that sibling `<Agent />` components are safe to run concurrently. Start independent evaluations with JavaScript concurrency primitives, then pass their results into a later `<Agent />`:
+AML does not infer that ordinary sibling `<Agent />` components are safe to run concurrently. Wrap independent
+text-producing branches in [`<Parallel>`](/docs/reference/primitives/parallel/):
 
 ```tsx
-async function Review() {
-  const [correctness, maintainability] = await Promise.all([
-    evaluate(<Agent>Review correctness.</Agent>),
-    evaluate(<Agent>Review maintainability.</Agent>),
-  ])
-
+function Review() {
   return (
     <Agent>
-      Correctness:
-      {correctness}
-      Maintainability:
-      {maintainability}
+      <Parallel>
+        <Agent>Review correctness.</Agent>
+        <Agent>Review maintainability.</Agent>
+      </Parallel>
     </Agent>
   )
 }
 ```
 
-The array keeps the authored `[correctness, maintainability]` order even if the second provider call finishes first. `maxConcurrentAgents` limits active provider calls; it does not turn sequential JSX into concurrent work.
+`<Parallel>` keeps authored branch order even if the second provider call finishes first. It waits for every branch and
+its cleanup before the parent continues. `maxConcurrentAgents` limits active provider calls; it does not turn ordinary
+sequential JSX into concurrent work.
+
+Use `Promise.all([evaluate(...), evaluate(...)])` inside an active async component when JavaScript needs named or typed
+branch values before authoring the next AML node. Both forms inherit the same evaluation domain, cancellation, resource
+scopes, budgets, tracing, and Agent scheduler.
 
 ## Lexical scope and cleanup
 

--- a/apps/website/src/content/docs/docs/cookbook/code-review-workflow.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/code-review-workflow.mdx
@@ -168,6 +168,12 @@ The specialist text is intentionally visible in the final prompt. A production w
 
 </Steps>
 
+<Aside type="note" title="Choose the boundary that matches the result shape">
+  This recipe uses `Promise.all(evaluate(...))` because the component binds two named JavaScript strings before
+  authoring the synthesis Agent. Use [`<Parallel>`](/docs/reference/primitives/parallel/) when independent branch text
+  can flow directly into the surrounding AML tree without an intermediate JavaScript transformation.
+</Aside>
+
 ## Failure and security notes
 
 <Aside type="caution" title="Tools execute in the host process">
@@ -180,6 +186,7 @@ The specialist text is intentionally visible in the final prompt. A production w
 </Aside>
 
 - A specialist failure rejects the `Promise.all`; the synthesis does not run with partial evidence.
+- `<Parallel>` also remains all-or-nothing, but waits for every branch and reports ordered failures through `ParallelError`.
 - A [`<Tool />`](/docs/reference/primitives/tool/) input or output that violates its schema fails closed.
 - A real provider can hallucinate or misread evidence. Treat the final review as an input to a human or policy gate, not as proof.
 - For untrusted workflows, set finite runtime budgets such as `maxAgentCalls`, `maxConcurrentAgents`, and `maxTurnsPerAgent`.
@@ -187,6 +194,7 @@ The specialist text is intentionally visible in the final prompt. A production w
 ## API and source links
 
 - [`<Agent />`](/docs/reference/primitives/agent/)
+- [`<Parallel />`](/docs/reference/primitives/parallel/)
 - [`evaluate()`](/docs/reference/runtime/#component-local-evaluation)
 - [`defineTool()`](/docs/reference/primitives/tool/)
 - [`AmlRuntime`](/docs/reference/runtime/)

--- a/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/follow-up-editorial-passes.mdx
@@ -127,7 +127,7 @@ The important observable behavior is session shape: the provider receives one in
 - Use separate evaluations for schema-validated editorial stages: outline → host validation → critique → host policy → final writer. This exposes intermediate values at the cost of multiple Agent sessions.
 - Keep a fixed FollowUp chain for predictable editorial passes where provider-owned history is desirable and no host decision belongs between turns.
 - Add a final structured-output boundary only if the provider supports it for the final turn; earlier FollowUp responses remain session history rather than typed host values.
-- For independent reviewers, use separate `evaluate()` calls and explicit JavaScript concurrency instead of placing parallel work in one `<FollowUp />` chain.
+- For independent reviewers whose text flows directly onward, use `<Parallel>` instead of placing concurrent work in one `<FollowUp />` chain. Use separate `evaluate()` calls when host code needs each result.
 
 ## API and source links
 

--- a/apps/website/src/content/docs/docs/examples.mdx
+++ b/apps/website/src/content/docs/docs/examples.mdx
@@ -52,7 +52,7 @@ The shared example runner remains useful for its catalog and common tracer. Use 
 
   </Card>
   <Card title="Run specialists in parallel" icon="random">
-    Run `concurrency` to see `Promise.all` create explicit concurrency while preserving result order.
+    Run `concurrency` to see `<Parallel>` overlap independent Agents while preserving authored result order.
 
     [`core/concurrency.tsx`](https://github.com/we-are-singular/aml/blob/main/examples/src/core/concurrency.tsx)
 

--- a/apps/website/src/content/docs/docs/faq.mdx
+++ b/apps/website/src/content/docs/docs/faq.mdx
@@ -79,7 +79,10 @@ The [runtime guide](/docs/runtime/) covers application-owned evaluation, limits,
 
 ### Can one workflow use more than one coding agent?
 
-Yes. One agent's result can become another agent's input, and independent agents can work concurrently with ordinary `Promise.all()`. Each [`<Agent />`](/docs/reference/primitives/agent/) is still a separate session with its own explicitly granted instructions and capabilities.
+Yes. One agent's result can become another agent's input, and independent text-producing branches can run concurrently
+inside [`<Parallel>`](/docs/reference/primitives/parallel/). Use ordinary `Promise.all(evaluate(...))` when component
+code needs the individual results. Each [`<Agent />`](/docs/reference/primitives/agent/) remains a separate session with
+its own explicitly granted instructions and capabilities.
 
 See the [code-review workflow](/docs/cookbook/code-review-workflow/) for both parallel review and a final synthesis step.
 

--- a/apps/website/src/content/docs/docs/index.mdx
+++ b/apps/website/src/content/docs/docs/index.mdx
@@ -39,7 +39,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components"
   </CardGrid>
 </div>
 
-AML is an asynchronous TypeScript and JSX runtime for building executable agent workflows. JSX describes the dependency tree; [`AmlRuntime`](/docs/reference/runtime/) evaluates it, opens scoped resources, runs provider sessions, and cleans up in reverse order. It is not a UI framework or a second workflow language—ordinary TypeScript still owns control flow and concurrency.
+AML is an asynchronous TypeScript and JSX runtime for building executable agent workflows. JSX describes the dependency tree; [`AmlRuntime`](/docs/reference/runtime/) evaluates it, opens scoped resources, runs provider sessions, and cleans up in reverse order. It is not a UI framework or a second workflow language—ordinary TypeScript owns control flow, while [`<Parallel>`](/docs/reference/primitives/parallel/) explicitly marks independent AML branches.
 
 ## Install AML
 

--- a/apps/website/src/content/docs/docs/providers/agents/index.mdx
+++ b/apps/website/src/content/docs/docs/providers/agents/index.mdx
@@ -152,7 +152,9 @@ const answer = await new AmlRuntime().evaluate(
 )
 ```
 
-For independent specialist evaluations, use explicit `Promise.all([evaluate(...)])`. AML's scheduler and budgets remain in charge; JavaScript concurrency is the authored boundary.
+For independent specialist branches whose text flows directly into the tree, use
+[`<Parallel>`](/docs/reference/primitives/parallel/). Use explicit `Promise.all([evaluate(...)])` when component code
+needs named or typed results. AML's scheduler and budgets remain in charge in both forms.
 
 ## Cross-provider capability matrix
 

--- a/apps/website/src/content/docs/docs/reference/primitives/fragment.mdx
+++ b/apps/website/src/content/docs/docs/reference/primitives/fragment.mdx
@@ -33,7 +33,7 @@ The automatic JSX transform imports `Fragment` from `@aml-jsx/sdk/jsx-runtime`; 
 - Children are resolved and concatenated in authored order.
 - `<>…</>` inserts no separators or prompt text of its own.
 - It creates no Agent, Sandbox, Workspace, capability, trace, or cleanup boundary.
-- It does not start siblings concurrently. Use `Promise.all()` around component-local [`evaluate()`](/docs/reference/runtime/#component-local-evaluation) calls when independent work may overlap.
+- It does not start siblings concurrently. Use [`<Parallel>`](/docs/reference/primitives/parallel/) for independent text-producing branches, or `Promise.all()` around component-local [`evaluate()`](/docs/reference/runtime/#component-local-evaluation) calls when JavaScript needs each result.
 - Descriptor placement still follows the eventual containing boundary. A `<System />` or `<Tool />` inside `<>…</>` still belongs to its nearest [`<Agent />`](/docs/reference/primitives/agent/).
 
 An explicit `<Fragment>…</Fragment>` form is also exported, but shorthand fragments are the conventional authoring form. See [AST and evaluation](/docs/ast/) for renderable values and node construction.

--- a/apps/website/src/content/docs/docs/reference/primitives/index.mdx
+++ b/apps/website/src/content/docs/docs/reference/primitives/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: AML primitives
-description: Reference the eleven stable AML authoring primitives, their placement rules, results, and composition boundaries.
+description: Reference the twelve stable AML authoring primitives, their placement rules, results, and composition boundaries.
 ---
 
 import { Aside } from "@astrojs/starlight/components"
 import PrimitiveCatalog from "../../../../../components/docs/PrimitiveCatalog.astro"
 
-AML has eleven stable authoring primitives. Each exists because the runtime must own a distinct piece of evaluation, capability scope, or resource lifecycle. Branching, finite iteration, retries, concurrency, and data transformation remain ordinary TypeScript.
+AML has twelve stable authoring primitives. Each exists because the runtime must own a distinct piece of evaluation, capability scope, or resource lifecycle. Branching, finite iteration, retries, and data transformation remain ordinary TypeScript; [`<Parallel>`](/docs/reference/primitives/parallel/) is the explicit boundary for independent AML branches.
 
 <PrimitiveCatalog />
 
@@ -15,6 +15,7 @@ AML has eleven stable authoring primitives. Each exists because the runtime must
 | Responsibility                | Start with                                                | Add when needed                                                                                                                                                                                                                                             |
 | ----------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Run a provider session        | [`<Agent />`](/docs/reference/primitives/agent/)          | [`<System />`](/docs/reference/primitives/system/), [`<Tool />`](/docs/reference/primitives/tool/), [`<Mcp />`](/docs/reference/primitives/mcp/), [`<Skill />`](/docs/reference/primitives/skill/), [`<FollowUp />`](/docs/reference/primitives/follow-up/) |
+| Run independent AML branches  | [`<Parallel />`](/docs/reference/primitives/parallel/)    | Function components or Fragments when one branch contains ordered steps                                                                                                                                                                                     |
 | Execute a command             | [`<Script />`](/docs/reference/primitives/script/)        | [`<Sandbox />`](/docs/reference/primitives/sandbox/) when it must run in a selected environment                                                                                                                                                             |
 | Materialize or preserve files | [`<Workspace />`](/docs/reference/primitives/workspace/)  | [`<File />`](/docs/reference/primitives/file/) and, when commands are needed, [`<Sandbox />`](/docs/reference/primitives/sandbox/)                                                                                                                          |
 | Group authored values         | [Fragment `<>…</>`](/docs/reference/primitives/fragment/) | Function components and ordinary TypeScript                                                                                                                                                                                                                 |

--- a/apps/website/src/content/docs/docs/reference/primitives/parallel.mdx
+++ b/apps/website/src/content/docs/docs/reference/primitives/parallel.mdx
@@ -1,0 +1,133 @@
+---
+title: "<Parallel />"
+description: Evaluate independent AML branches concurrently, preserve authored output order, and report every failure after cleanup.
+---
+
+import { Aside } from "@astrojs/starlight/components"
+
+`<Parallel />` is AML's explicit concurrency boundary for text-producing branches. It starts each branch through
+component-local [`evaluate()`](/docs/reference/runtime/#component-local-evaluation), waits for all branches and their
+cleanup, then contributes successful text in authored order.
+
+```tsx
+import { Agent, AmlRuntime, Parallel } from "@aml-jsx/sdk"
+
+function CorrectnessLane() {
+  return <Agent>Review correctness.</Agent>
+}
+
+function SecurityLane() {
+  return <Agent>Review security.</Agent>
+}
+
+const result = await new AmlRuntime({ agentProvider }).evaluate(
+  <Agent system="Synthesize only the supplied reviews.">
+    <Parallel>
+      <CorrectnessLane />
+      <SecurityLane />
+    </Parallel>
+  </Agent>
+)
+```
+
+The two lanes may finish in either order. The parent Agent starts only after both settle and receives their text in the
+authored `CorrectnessLane`, `SecurityLane` order.
+
+## Props
+
+| Prop       | Type            | Default | Meaning                                      |
+| ---------- | --------------- | ------- | -------------------------------------------- |
+| `children` | `AmlRenderable` | empty   | Independent branches evaluated concurrently. |
+
+`<Parallel>` has no `concurrency`, retry, error callback, quorum, partial-result, or fail-fast cancellation prop.
+[`maxConcurrentAgents`](/docs/reference/runtime/#runtime-options) remains the single limit for active Agent provider
+calls in the evaluation domain.
+
+## Branches and ordering
+
+Each immediate child is one branch. Child arrays are recursively flattened so mapped workflows behave naturally:
+
+```tsx
+<Parallel>
+  {reviewKinds.map(kind => (
+    <ReviewLane kind={kind} />
+  ))}
+</Parallel>
+```
+
+`null`, `undefined`, and booleans contribute no branch. A Fragment remains one branch, and the values inside it keep
+ordinary sequential semantics:
+
+```tsx
+<Parallel>
+  <>
+    lane-a:
+    <Agent>Run lane A.</Agent>
+  </>
+  <>
+    lane-b:
+    <Agent>Run lane B.</Agent>
+  </>
+</Parallel>
+```
+
+Branch output is isolated while work is active. Completion order never changes the rendered result order, and AML does
+not insert separators between branch strings.
+
+## Structured branch output
+
+An Agent-owned [`schema`](/docs/reference/primitives/agent/#resolution-and-result) remains valid inside a branch. Its
+validated value contributes canonical JSON text like any other nested Agent result:
+
+```tsx
+<Parallel>
+  <Agent schema={LaneResult}>Review correctness.</Agent>
+  <Agent schema={LaneResult}>Review security.</Agent>
+</Parallel>
+```
+
+`<Parallel>` itself is a text-composition boundary. Do not pass a schema to `evaluate(<Parallel>...</Parallel>, schema)`
+to collect several typed results. Use `Promise.all([evaluate(branch, schema), ...])` in component code when JavaScript
+needs named or schema-inferred branch values.
+
+## Failure semantics
+
+One or more rejected branches produce the same exported `ParallelError`. Its `failures` array preserves authored branch
+order and contains the zero-based branch index plus that branch's original rejection:
+
+```tsx
+import { ParallelError } from "@aml-jsx/sdk"
+
+try {
+  await runtime.evaluate(<Review />)
+} catch (error) {
+  if (error instanceof ParallelError) {
+    for (const failure of error.failures) {
+      console.error(`Branch ${failure.branchIndex + 1} failed`, failure.cause)
+    }
+  }
+}
+```
+
+`<Parallel>` uses wait-for-all semantics. It does not throw as soon as the first branch rejects, because enclosing
+Sandbox and Workspace resources must remain available until every started branch completes cleanup. Caller cancellation
+still propagates through the evaluation signal: active providers receive it, queued Agents do not start, and the boundary
+waits for their resulting evaluations to settle.
+
+<Aside type="caution" title="Parallel side effects are not transactional">
+  A successful branch may already have called Tools, changed files, or reached external services before another branch
+  fails. `<Parallel>` does not retry branches or roll back completed effects. Give shared mutable resources
+  concurrency-safe ownership and place retry policy at the operation that knows whether replay is safe.
+</Aside>
+
+## Placement and descriptor isolation
+
+`<Parallel>` may appear wherever ordinary component text is valid, including inside an Agent, Sandbox, or Workspace. It
+inherits the active Context, Sandbox, Workspace, cancellation, budgets, tracing, and Agent scheduler.
+
+Each branch is its own nested evaluation. Direct `<System>`, `<Tool>`, `<Mcp>`, `<Skill>`, or `<FollowUp>` children do not
+attach to an Agent surrounding `<Parallel>`; put Agent-owned descriptors inside that branch's own `<Agent>`.
+
+See the runnable [`concurrency` example](https://github.com/we-are-singular/aml/blob/main/examples/src/core/concurrency.tsx),
+[the evaluation model](/docs/concepts/#explicit-concurrency), and
+[`evaluate()`](/docs/reference/runtime/#component-local-evaluation).

--- a/apps/website/src/content/docs/docs/reference/runtime.mdx
+++ b/apps/website/src/content/docs/docs/reference/runtime.mdx
@@ -83,9 +83,19 @@ The schema remains application-owned. AML derives the provider-facing JSON Schem
 
 Use `<Agent schema={ReportSchema}>` instead when a nested Agent should validate its own boundary and contribute canonical JSON text to the surrounding AML tree. An Agent `schema` prop and the second `evaluate()` argument are alternative schema owners and cannot be combined on the same Agent.
 
+## Parallel branches
+
+[`<Parallel>`](/docs/reference/primitives/parallel/) uses component-local `evaluate()` to start independent AML branches
+inside the current evaluation domain. Branches inherit the active Context, Sandbox, Workspace, trace ancestry, limits,
+and cancellation. Their output stays isolated until every branch settles, then renders in authored order.
+
+`maxConcurrentAgents` remains the only Agent-session concurrency limit. `<Parallel>` adds no second scheduler. Use
+manual `Promise.all(evaluate(...))` when component code needs individual or schema-inferred results instead of direct
+text composition.
+
 ## Errors and lifecycle events
 
-`EvaluationError` identifies invalid authored AML values and evaluator invariants. Provider failures, schema failures, capability validation, cancellation, and cleanup failures retain their original causes where possible. Catch `EvaluationError` when you specifically need to distinguish an AML authoring/runtime failure from an upstream failure.
+`EvaluationError` identifies invalid authored AML values and evaluator invariants. Provider failures, schema failures, capability validation, cancellation, and cleanup failures retain their original causes where possible. Catch `EvaluationError` when you specifically need to distinguish an AML authoring/runtime failure from an upstream failure. `ParallelError` reports one or more failed [`<Parallel>`](/docs/reference/primitives/parallel/#failure-semantics) branches through ordered `{ branchIndex, cause }` entries.
 
 `start` and `finish` listeners are awaited. Trace sinks are dispatched according to their own policy and do not delay workflow completion:
 

--- a/apps/website/src/scenarios.ts
+++ b/apps/website/src/scenarios.ts
@@ -41,28 +41,33 @@ export interface Scenario {
   duration: number
 }
 
-const REVIEW_CODE = `import { Agent, AmlRuntime, evaluate } from "@aml-jsx/sdk"
+const REVIEW_CODE = `import { Agent, AmlRuntime, Parallel, Tool } from "@aml-jsx/sdk"
 
-async function Review() {
-  const [correctness, maintainability] = await Promise.all([
-    evaluate(
-      <Agent provider={OpenCode} system="Find concrete correctness defects.">
-        <Tool use={ReadSource} />
-        Review src/index.ts.
-      </Agent>,
-    ),
-    evaluate(
-      <Agent provider={OpenCode} system="Find proportionate improvements.">
-        <Tool use={ReadSource} />
-        Review src/index.ts.
-      </Agent>,
-    ),
-  ])
+function CorrectnessLane() {
+  return (
+    <Agent provider={OpenCode} system="Find concrete correctness defects.">
+      <Tool use={ReadSource} />
+      Review src/index.ts.
+    </Agent>
+  )
+}
 
+function MaintainabilityLane() {
+  return (
+    <Agent provider={OpenCode} system="Find proportionate improvements.">
+      <Tool use={ReadSource} />
+      Review src/index.ts.
+    </Agent>
+  )
+}
+
+function Review() {
   return (
     <Agent provider={OpenCode} system="Synthesize evidence, invent nothing.">
-      Correctness: {correctness}
-      Maintainability: {maintainability}
+      <Parallel>
+        <CorrectnessLane />
+        <MaintainabilityLane />
+      </Parallel>
     </Agent>
   )
 }
@@ -77,28 +82,32 @@ Maintainability: extract provider dispatch into a named helper.
 const review: Scenario = {
   id: "review",
   tab: "parallel specialists",
-  title: "Promise.all() concurrency + ordered synthesis",
+  title: "<Parallel> concurrency + ordered synthesis",
   file: "examples/src/core/concurrency.tsx",
   code: REVIEW_CODE,
   nodes: [
     { id: "tool", label: "<Tool /> read_source", x: 150, y: 30 },
     { id: "spec-a", label: "<Agent /> correctness", x: 150, y: 100 },
     { id: "spec-b", label: "<Agent /> maintainability", x: 420, y: 100 },
-    { id: "synth", label: "<Agent /> synthesize", x: 280, y: 185 },
-    { id: "root", label: "<Review />", x: 280, y: 258 },
+    { id: "parallel", label: "<Parallel />", x: 280, y: 160 },
+    { id: "synth", label: "<Agent /> synthesize", x: 280, y: 220 },
+    { id: "root", label: "<Review />", x: 280, y: 280 },
   ],
   edges: [
     { id: "e-root", from: "root", to: "synth" },
-    { id: "e-a", from: "synth", to: "spec-a" },
-    { id: "e-b", from: "synth", to: "spec-b" },
+    { id: "e-parallel", from: "synth", to: "parallel" },
+    { id: "e-a", from: "parallel", to: "spec-a" },
+    { id: "e-b", from: "parallel", to: "spec-b" },
     { id: "e-tool", from: "spec-a", to: "tool" },
   ],
   events: [
-    { at: 0, kind: "code", lines: [27] },
+    { at: 0, kind: "code", lines: [32] },
     { at: 0, kind: "trace", text: "evaluation:start tree=<Review />", tone: "info" },
     { at: 350, kind: "node", id: "root", state: "resolving" },
-    { at: 350, kind: "code", lines: [3] },
-    { at: 750, kind: "code", lines: [4] },
+    { at: 350, kind: "code", lines: [21] },
+    { at: 750, kind: "node", id: "parallel", state: "resolving" },
+    { at: 750, kind: "edge", id: "e-parallel", state: "hot" },
+    { at: 750, kind: "code", lines: [24] },
     { at: 900, kind: "node", id: "spec-a", state: "resolving" },
     { at: 900, kind: "edge", id: "e-a", state: "hot" },
     { at: 900, kind: "edge", id: "e-b", state: "hot" },
@@ -108,33 +117,35 @@ const review: Scenario = {
     { at: 1500, kind: "node", id: "tool", state: "done" },
     { at: 1500, kind: "trace", text: "tool:grant read_source → correctness", tone: "ok" },
     { at: 1650, kind: "node", id: "spec-b", state: "resolving" },
-    { at: 1650, kind: "code", lines: [12, 13] },
+    { at: 1650, kind: "code", lines: [14, 15] },
     { at: 1950, kind: "trace", text: "tool:grant read_source → maintainability", tone: "ok" },
     { at: 2150, kind: "node", id: "spec-a", state: "running" },
     { at: 2150, kind: "trace", text: "agent:start correctness provider=opencode", tone: "info" },
     { at: 2400, kind: "node", id: "spec-b", state: "running" },
     { at: 2400, kind: "trace", text: "agent:start maintainability provider=opencode", tone: "info" },
-    { at: 2400, kind: "code", lines: [6, 12] },
+    { at: 2400, kind: "code", lines: [5, 14] },
     { at: 3300, kind: "trace", text: 'tool:call read_source path="src/index.ts"', tone: "info" },
     { at: 3550, kind: "trace", text: "tool:result 4_812 chars", tone: "ok" },
     { at: 4600, kind: "node", id: "spec-b", state: "done" },
     { at: 4600, kind: "edge", id: "e-b", state: "done" },
     { at: 4600, kind: "trace", text: "agent:done maintainability ms=2_200 (finishes first)", tone: "ok" },
-    { at: 4600, kind: "code", lines: [6] },
+    { at: 4600, kind: "code", lines: [14] },
     { at: 5400, kind: "node", id: "spec-a", state: "done" },
     { at: 5400, kind: "edge", id: "e-a", state: "done" },
     { at: 5400, kind: "trace", text: "agent:done correctness ms=3_250", tone: "ok" },
+    { at: 5600, kind: "node", id: "parallel", state: "done" },
+    { at: 5600, kind: "edge", id: "e-parallel", state: "done" },
     { at: 5700, kind: "node", id: "synth", state: "resolving" },
-    { at: 5700, kind: "code", lines: [19, 20] },
+    { at: 5700, kind: "code", lines: [23, 24] },
     { at: 5700, kind: "trace", text: "agent:prepare synthesize prompt += 2 results (authored order)", tone: "info" },
     { at: 6100, kind: "node", id: "synth", state: "running" },
     { at: 6100, kind: "trace", text: "agent:start synthesize provider=opencode", tone: "info" },
-    { at: 6100, kind: "code", lines: [21, 22] },
+    { at: 6100, kind: "code", lines: [23, 28] },
     { at: 7900, kind: "node", id: "synth", state: "done" },
     { at: 7900, kind: "edge", id: "e-root", state: "done" },
     { at: 7900, kind: "trace", text: "agent:done synthesize ms=1_800", tone: "ok" },
     { at: 8100, kind: "node", id: "root", state: "done" },
-    { at: 8100, kind: "code", lines: [27] },
+    { at: 8100, kind: "code", lines: [32] },
     { at: 8100, kind: "trace", text: "evaluation:end ms=8_100 output=text", tone: "ok" },
     { at: 8300, kind: "output", text: REVIEW_OUTPUT },
   ],

--- a/examples/src/core/concurrency.tsx
+++ b/examples/src/core/concurrency.tsx
@@ -1,4 +1,4 @@
-import { Agent, evaluate } from "@aml-jsx/sdk"
+import { Agent, Parallel } from "@aml-jsx/sdk"
 import { DeterministicAgentProvider } from "@aml-jsx/sdk/testing"
 
 /**
@@ -22,17 +22,26 @@ const ExampleProvider = new DeterministicAgentProvider({
 })
 
 /**
- * Starts independent specialists explicitly, then authors one coordinator.
+ * Runs one independent specialist and contributes its labeled result.
  */
-async function Review() {
-  const [review, audit] = await Promise.all([
-    evaluate(<Agent provider={ExampleProvider}>review</Agent>),
-    evaluate(<Agent provider={ExampleProvider}>audit</Agent>),
-  ])
+function ReviewLane() {
+  return [<Agent provider={ExampleProvider}>review</Agent>, "|"]
+}
 
+/** Runs the second independent specialist. */
+function AuditLane() {
+  return <Agent provider={ExampleProvider}>audit</Agent>
+}
+
+/** Starts both specialists explicitly, then authors one coordinator. */
+function Review() {
   return (
     <Agent provider={ExampleProvider}>
-      combine:{review}|{audit}
+      combine:
+      <Parallel>
+        <ReviewLane />
+        <AuditLane />
+      </Parallel>
     </Agent>
   )
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -47,6 +47,22 @@ Codex, GitHub Copilot, GLM, OpenCode, and Pi use the same ACP lifecycle on the t
 
 `<Agent schema={Result}>` validates that Agent's structured result and contributes canonical JSON text to ordinary AML composition. An authored `<FollowUp>` sequence remains valid: AML asks for structured output only on the final authored turn. Use `evaluate(<Agent>...</Agent>, Result)` instead when component code needs the schema-inferred value.
 
+`<Parallel>` evaluates independent AML branches concurrently, waits for every branch and its cleanup to settle, then
+contributes successful text in authored order. Agent-owned `schema` values remain canonical JSON text inside a branch.
+`AmlRuntime.maxConcurrentAgents` still bounds active Agent sessions; `<Parallel>` adds no second concurrency limit.
+When any branch fails, it throws `ParallelError` with ordered, zero-based `{ branchIndex, cause }` entries after all
+branches settle. It does not retry, cancel siblings after a failure, or roll back completed side effects.
+
+```tsx
+<Agent provider={Pi}>
+  <Parallel>
+    <Agent>Review correctness.</Agent>
+    <Agent>Review maintainability.</Agent>
+  </Parallel>
+  Synthesize the reviews.
+</Agent>
+```
+
 An unsandboxed `<Script />` runs as a trusted host process from `AmlRuntimeOptions.cwd`, defaulting to `process.cwd()`. Inside an active `<Sandbox />`, it runs only through that Sandbox runtime and never falls back to the host. Its optional portable `cwd` resolves from the runtime cwd on the host or from the active Sandbox root.
 
 The public factory names are `codexAgent()`, `copilotAgent()`, `glmAgent()`, `opencodeAgent()`, and `piAgent()`.

--- a/sdk/src/components/parallel/parallel.tsx
+++ b/sdk/src/components/parallel/parallel.tsx
@@ -1,0 +1,83 @@
+import type { AmlRenderable } from "../../core/aml-node.js"
+import { evaluate } from "../../core/evaluate.js"
+import { EvaluationError } from "../../core/evaluation-error.js"
+
+/** Independent AML branches evaluated concurrently in authored order. */
+export interface ParallelProps {
+  readonly children?: AmlRenderable
+}
+
+/** Identifies one failed Parallel branch without hiding its original cause. */
+export interface ParallelFailure {
+  readonly branchIndex: number
+  readonly cause: unknown
+}
+
+/** Reports every failed Parallel branch in authored order. */
+export class ParallelError extends Error {
+  readonly failures: readonly ParallelFailure[]
+
+  constructor(failures: readonly ParallelFailure[]) {
+    const branches = failures.map(failure => failure.branchIndex + 1).join(", ")
+    super(failures.length === 1 ? `<Parallel> branch ${branches} failed` : `<Parallel> branches ${branches} failed`)
+    this.name = "ParallelError"
+    this.failures = failures
+  }
+}
+
+/**
+ * Evaluates each flattened child concurrently and renders successful outputs
+ * in authored order after every branch has settled.
+ */
+export async function Parallel({ children }: ParallelProps): Promise<readonly string[]> {
+  const branches = flattenBranches(children)
+  const settled = await Promise.allSettled(branches.map(branch => evaluate(branch)))
+  const failures: ParallelFailure[] = []
+  const output: string[] = []
+
+  for (const [branchIndex, result] of settled.entries()) {
+    if (result.status === "rejected") {
+      failures.push({ branchIndex, cause: result.reason })
+    } else {
+      output.push(result.value)
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new ParallelError(failures)
+  }
+
+  return output
+}
+
+/** Flattens JSX child arrays while retaining fragments as explicit groups. */
+function flattenBranches(children: AmlRenderable): AmlRenderable[] {
+  const activeArrays = new Set<readonly AmlRenderable[]>()
+  const branches: AmlRenderable[] = []
+
+  function visit(value: AmlRenderable): void {
+    if (Array.isArray(value)) {
+      if (activeArrays.has(value)) {
+        throw new EvaluationError("AML arrays cannot contain cycles")
+      }
+
+      activeArrays.add(value)
+
+      for (const child of value) {
+        visit(child)
+      }
+
+      activeArrays.delete(value)
+      return
+    }
+
+    if (value === null || value === undefined || typeof value === "boolean") {
+      return
+    }
+
+    branches.push(value)
+  }
+
+  visit(children)
+  return branches
+}

--- a/sdk/src/core.ts
+++ b/sdk/src/core.ts
@@ -36,6 +36,7 @@ export type {
 export { FollowUp, type FollowUpProps } from "./components/follow-up/follow-up.js"
 export { File, type FileProps } from "./components/file/file.js"
 export { type DeepReadonly, Loop, type LoopProps, type LoopRenderContext } from "./components/loop/loop.js"
+export { Parallel, ParallelError, type ParallelFailure, type ParallelProps } from "./components/parallel/parallel.js"
 export { System, type SystemProps } from "./components/system/system.js"
 
 // Immutable downward-scoped application dependencies.

--- a/sdk/tests/parallel-runtime.test.tsx
+++ b/sdk/tests/parallel-runtime.test.tsx
@@ -9,6 +9,7 @@ import { Parallel, ParallelError } from "../src/components/parallel/parallel.js"
 import { Sandbox } from "../src/components/sandbox/sandbox.js"
 import { System } from "../src/components/system/system.js"
 import { AmlRuntime } from "../src/core/aml-runtime.js"
+import { EvaluationError } from "../src/core/evaluation-error.js"
 import { DeterministicAgentProvider } from "../src/testing/deterministic-agent-provider.js"
 import { DeterministicSandboxProvider } from "../src/testing/deterministic-sandbox-provider.js"
 
@@ -285,6 +286,71 @@ describe("Parallel", () => {
     finishSecond?.()
 
     await expect(evaluation).rejects.toMatchObject({ failures: [{ branchIndex: 0 }] })
+    expect(sandboxProvider.releases).toHaveLength(1)
+  })
+
+  it("reports branch cleanup failures only after every sibling settles", async () => {
+    const cleanupFailure = new Error("branch cleanup failed")
+    let finishSecond: (() => void) | undefined
+    const secondGate = new Promise<void>(resolve => {
+      finishSecond = resolve
+    })
+    const events: string[] = []
+    const sandboxProvider = new DeterministicSandboxProvider({
+      release() {
+        events.push("first:cleanup")
+        throw cleanupFailure
+      },
+    })
+
+    async function SlowLane() {
+      events.push("second:start")
+      await secondGate
+      events.push("second:end")
+      return "second"
+    }
+
+    const evaluation = new AmlRuntime().evaluate(
+      <Parallel>
+        <Sandbox provider={sandboxProvider}>first</Sandbox>
+        <SlowLane />
+      </Parallel>
+    )
+
+    await vi.waitFor(() => {
+      expect(events).toContain("first:cleanup")
+      expect(events).toContain("second:start")
+    })
+    let settled = false
+    void evaluation.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    finishSecond?.()
+
+    let error: unknown
+
+    try {
+      await evaluation
+    } catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(ParallelError)
+    if (!(error instanceof ParallelError)) {
+      throw new Error("Expected ParallelError")
+    }
+    expect(error.failures).toHaveLength(1)
+    expect(error.failures[0]?.branchIndex).toBe(0)
+    expect(error.failures[0]?.cause).toBeInstanceOf(EvaluationError)
+    expect(error.failures[0]?.cause).toMatchObject({ cause: cleanupFailure })
+    expect(events).toContain("second:end")
     expect(sandboxProvider.releases).toHaveLength(1)
   })
 

--- a/sdk/tests/parallel-runtime.test.tsx
+++ b/sdk/tests/parallel-runtime.test.tsx
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+
+import { Agent } from "../src/components/agent/agent.js"
+import type { AgentProvider } from "../src/components/agent/agent-provider.js"
+import { createContext } from "../src/components/context/create-context.js"
+import { useContext } from "../src/components/context/use-context.js"
+import { Parallel, ParallelError } from "../src/components/parallel/parallel.js"
+import { Sandbox } from "../src/components/sandbox/sandbox.js"
+import { System } from "../src/components/system/system.js"
+import { AmlRuntime } from "../src/core/aml-runtime.js"
+import { DeterministicAgentProvider } from "../src/testing/deterministic-agent-provider.js"
+import { DeterministicSandboxProvider } from "../src/testing/deterministic-sandbox-provider.js"
+
+describe("Parallel", () => {
+  it("overlaps flattened branches and renders their results in authored order", async () => {
+    const events: string[] = []
+    let releaseFast: (() => void) | undefined
+    let releaseSlow: (() => void) | undefined
+    const fastGate = new Promise<void>(resolve => {
+      releaseFast = resolve
+    })
+    const slowGate = new Promise<void>(resolve => {
+      releaseSlow = resolve
+    })
+    const provider = new DeterministicAgentProvider({
+      async respond(request) {
+        events.push(`${request.prompt}:start`)
+
+        if (request.prompt === "slow") {
+          await slowGate
+        } else {
+          await fastGate
+        }
+
+        events.push(`${request.prompt}:end`)
+        return { text: `${request.prompt}-result` }
+      },
+    })
+
+    const evaluation = new AmlRuntime({ agentProvider: provider }).evaluate(
+      <Parallel>{[<Agent>slow</Agent>, [null, false, <Agent>fast</Agent>]]}</Parallel>
+    )
+
+    await vi.waitFor(() => expect(events).toEqual(["slow:start", "fast:start"]))
+    releaseFast?.()
+    await vi.waitFor(() => expect(events).toContain("fast:end"))
+    releaseSlow?.()
+
+    await expect(evaluation).resolves.toBe("slow-resultfast-result")
+    expect(events).toEqual(["slow:start", "fast:start", "fast:end", "slow:end"])
+  })
+
+  it("renders Agent-owned structured output as ordered JSON text", async () => {
+    const LaneResult = z.object({ lane: z.string(), passed: z.boolean() })
+    const provider = new DeterministicAgentProvider({
+      respond: request => ({
+        structured: { lane: request.prompt, passed: true },
+        text: "ignored",
+      }),
+    })
+
+    await expect(
+      new AmlRuntime({ agentProvider: provider }).evaluate(
+        <Parallel>
+          <Agent schema={LaneResult}>correctness</Agent>
+          <Agent schema={LaneResult}>security</Agent>
+        </Parallel>
+      )
+    ).resolves.toBe('{"lane":"correctness","passed":true}{"lane":"security","passed":true}')
+  })
+
+  it("relies on maxConcurrentAgents to bound provider calls", async () => {
+    let active = 0
+    let calls = 0
+    let maxActive = 0
+    let release: (() => void) | undefined
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+    const provider = new DeterministicAgentProvider({
+      async respond(request) {
+        calls += 1
+        active += 1
+        maxActive = Math.max(maxActive, active)
+        await gate
+        active -= 1
+        return { text: request.prompt }
+      },
+    })
+
+    const evaluation = new AmlRuntime({
+      agentProvider: provider,
+      maxConcurrentAgents: 2,
+    }).evaluate(
+      <Parallel>
+        {Array.from({ length: 5 }, (_, index) => (
+          <Agent>{index}</Agent>
+        ))}
+      </Parallel>
+    )
+
+    await vi.waitFor(() => expect(calls).toBe(2))
+    expect(maxActive).toBe(2)
+    release?.()
+
+    await expect(evaluation).resolves.toBe("01234")
+    expect(calls).toBe(5)
+    expect(maxActive).toBe(2)
+  })
+
+  it("cancels active branches without starting queued Agents", async () => {
+    const controller = new AbortController()
+    const cancellation = new Error("stop Parallel")
+    const calls: string[] = []
+    const provider: AgentProvider = {
+      name: "parallel-cancellation",
+      run(request, context) {
+        calls.push(request.prompt)
+
+        return new Promise((_resolve, reject) => {
+          context.signal.addEventListener("abort", () => reject(context.signal.reason), { once: true })
+        })
+      },
+    }
+
+    const evaluation = new AmlRuntime({
+      agentProvider: provider,
+      maxConcurrentAgents: 1,
+    }).evaluate(
+      <Parallel>
+        <Agent>first</Agent>
+        <Agent>second</Agent>
+        <Agent>third</Agent>
+      </Parallel>,
+      { signal: controller.signal }
+    )
+
+    await vi.waitFor(() => expect(calls).toEqual(["first"]))
+    controller.abort(cancellation)
+
+    const error = await evaluation.catch(error => error as unknown)
+    expect(error).toBeInstanceOf(ParallelError)
+    const failures = (error as ParallelError).failures
+    expect(failures.map(failure => failure.branchIndex)).toEqual([0, 1, 2])
+
+    for (const failure of failures) {
+      expect((failure.cause as Error).cause).toBe(cancellation)
+    }
+
+    expect(calls).toEqual(["first"])
+  })
+
+  it("identifies a single failed flattened branch and preserves its cause", async () => {
+    const cause = new Error("lane failed")
+
+    function FailingLane(): never {
+      throw cause
+    }
+
+    const error = await new AmlRuntime()
+      .evaluate(<Parallel>{["first", [null, <FailingLane />]]}</Parallel>)
+      .catch(error => error as unknown)
+
+    expect(error).toBeInstanceOf(ParallelError)
+    expect(error).toMatchObject({
+      failures: [{ branchIndex: 1, cause }],
+      message: "<Parallel> branch 2 failed",
+    })
+  })
+
+  it("waits for every branch and aggregates failures in authored order", async () => {
+    const first = new Error("first failed")
+    const third = new Error("third failed")
+    let finishSecond: (() => void) | undefined
+    const secondGate = new Promise<void>(resolve => {
+      finishSecond = resolve
+    })
+    const events: string[] = []
+
+    function FailingLane({ error }: Readonly<{ error: Error }>): never {
+      events.push(error.message)
+      throw error
+    }
+
+    async function SlowLane() {
+      events.push("second:start")
+      await secondGate
+      events.push("second:end")
+      return "second"
+    }
+
+    const evaluation = new AmlRuntime().evaluate(
+      <Parallel>
+        <FailingLane error={first} />
+        <SlowLane />
+        <FailingLane error={third} />
+      </Parallel>
+    )
+
+    await vi.waitFor(() => expect(events).toEqual(["first failed", "second:start", "third failed"]))
+    let settled = false
+    void evaluation.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    finishSecond?.()
+
+    const error = await evaluation.catch(error => error as unknown)
+    expect(error).toBeInstanceOf(ParallelError)
+    expect(error).toMatchObject({ message: "<Parallel> branches 1, 3 failed" })
+    expect((error as ParallelError).failures).toMatchObject([
+      { branchIndex: 0, cause: first },
+      { branchIndex: 2, cause: third },
+    ])
+    expect(events).toEqual(["first failed", "second:start", "third failed", "second:end"])
+  })
+
+  it("inherits Context and keeps branch-local Providers isolated", async () => {
+    const LaneContext = createContext("ParallelLane", "outer")
+
+    function ReadLane() {
+      return useContext(LaneContext)
+    }
+
+    await expect(
+      new AmlRuntime().evaluate(
+        <Parallel>
+          <LaneContext.Provider value="inner">
+            <ReadLane />
+          </LaneContext.Provider>
+          <ReadLane />
+        </Parallel>
+      )
+    ).resolves.toBe("innerouter")
+  })
+
+  it("supports nested Parallel components", async () => {
+    await expect(
+      new AmlRuntime().evaluate(
+        <Parallel>
+          <Parallel>{["a", "b"]}</Parallel>
+          <Parallel>{["c", "d"]}</Parallel>
+        </Parallel>
+      )
+    ).resolves.toBe("abcd")
+  })
+
+  it("joins branch cleanup before releasing an inherited Sandbox", async () => {
+    let finishSecond: (() => void) | undefined
+    const secondGate = new Promise<void>(resolve => {
+      finishSecond = resolve
+    })
+    const sandboxProvider = new DeterministicSandboxProvider()
+    const provider: AgentProvider = {
+      name: "parallel-cleanup",
+      async run(request) {
+        if (request.prompt === "fails") {
+          throw new Error("expected failure")
+        }
+
+        await secondGate
+        return { text: "done" }
+      },
+      supportsSandbox: () => true,
+    }
+
+    const evaluation = new AmlRuntime({ agentProvider: provider }).evaluate(
+      <Sandbox provider={sandboxProvider}>
+        <Parallel>
+          <Agent>fails</Agent>
+          <Agent>waits</Agent>
+        </Parallel>
+      </Sandbox>
+    )
+
+    await vi.waitFor(() => expect(provider).toMatchObject({ name: "parallel-cleanup" }))
+    expect(sandboxProvider.releases).toHaveLength(0)
+    finishSecond?.()
+
+    await expect(evaluation).rejects.toMatchObject({ failures: [{ branchIndex: 0 }] })
+    expect(sandboxProvider.releases).toHaveLength(1)
+  })
+
+  it("keeps Agent descriptors inside their own branches", async () => {
+    const error = await new AmlRuntime()
+      .evaluate(
+        <Agent provider={new DeterministicAgentProvider()}>
+          <Parallel>
+            <System>not a surrounding Agent descriptor</System>
+          </Parallel>
+        </Agent>
+      )
+      .catch(error => error as unknown)
+
+    expect(error).toMatchObject({
+      failures: [
+        {
+          branchIndex: 0,
+          cause: expect.objectContaining({ message: "<System> is only valid inside <Agent>" }),
+        },
+      ],
+    })
+  })
+})

--- a/sdk/tests/smoke/kitchen-sink.smoke.tsx
+++ b/sdk/tests/smoke/kitchen-sink.smoke.tsx
@@ -18,6 +18,7 @@ import {
   FollowUp,
   localWorkspace,
   Mcp,
+  Parallel,
   Sandbox,
   Script,
   Skill,
@@ -184,8 +185,18 @@ async function runKitchenSink(selection: KitchenSinkSelection): Promise<void> {
  */
 async function KitchenSinkAgent({ mcp, model, proofs, proofTool }: KitchenSinkAgentProps) {
   const expectedMcp = mcp === undefined ? "skipped" : "context7"
-  const nestedAgent = await evaluate(<NestedRemoteProof model={model} proofs={proofs} />)
-  assert.equal(nestedAgent.trim(), proofs.nestedAgent, "Nested Agent composition returned an unexpected proof")
+  const parallelProof = await evaluate(
+    <Parallel>
+      <NestedRemoteProof model={model} proofs={proofs} />
+      <InputFileProof proofs={proofs} />
+    </Parallel>
+  )
+  assert.equal(
+    parallelProof.trim(),
+    `${proofs.nestedAgent}input-ok`,
+    "Parallel composition returned proofs outside authored order"
+  )
+  const nestedAgent = proofs.nestedAgent
   const Result = z.object({
     command: z.literal(proofs.command),
     input: z.literal(proofs.input),
@@ -270,6 +281,16 @@ writeFileSync("shell.txt", ${JSON.stringify(proofs.shell)});
 process.stdout.write(${JSON.stringify(proofs.shell)});`}
     </Script>
   )
+}
+
+function InputFileProof({ proofs }: Readonly<{ proofs: KitchenSinkProofs }>) {
+  const source = [
+    'import { readFileSync } from "node:fs";',
+    `if (readFileSync("input.txt", "utf8") !== ${JSON.stringify(proofs.input)}) throw new Error("unexpected input.txt");`,
+    'process.stdout.write("input-ok");',
+  ].join("")
+
+  return <Script command="node" args={["--input-type=module", "--eval", source]} />
 }
 
 function createMcp(name: KitchenSinkMcpName): AmlMcpServer | undefined {

--- a/skills/aml-jsx/SKILL.md
+++ b/skills/aml-jsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aml-jsx
-description: Build, explain, test, or debug TypeScript agent workflows with Agent Markup Language and the @aml-jsx/sdk package. Use when a coding task involves AML, AML JSX/TSX trees, Agent/System/Tool/Skill/Mcp/FollowUp components, provider-agnostic multi-agent orchestration, explicit parallel agents, structured agent output, Sandboxes, Workspaces, OpenCode, Codex, GitHub Copilot, GLM, or Pi providers, or custom AML providers.
+description: Build, explain, test, or debug TypeScript agent workflows with Agent Markup Language and the @aml-jsx/sdk package. Use when a coding task involves AML, AML JSX/TSX trees, Agent/Parallel/System/Tool/Skill/Mcp/FollowUp components, provider-agnostic multi-agent orchestration, explicit parallel agents, structured agent output, Sandboxes, Workspaces, OpenCode, Codex, GitHub Copilot, GLM, or Pi providers, or custom AML providers.
 ---
 
 # Build with AML JSX
@@ -72,7 +72,7 @@ Follow these semantics:
 - `evaluate(tree)` is only for work started inside an actively evaluated AML function component.
 - AML resolves children from the leaves upward and preserves authored order.
 - A nested Agent resolves before its parent Agent; its text becomes part of the parent prompt at the authored position.
-- Sibling JSX does not imply concurrency. Start independent branches with `Promise.all()` and `evaluate()`.
+- Sibling JSX does not imply concurrency. Use `<Parallel>` for independent text-producing branches; use `Promise.all()` and `evaluate()` when component code needs individual or typed results.
 - Keep JavaScript control flow in TypeScript: use functions, arrays, conditions, loops, and promises rather than inventing markup primitives.
 - Inject providers through `<Agent provider={...}>` or runtime defaults so the tree remains provider-agnostic.
 - Scope `<Tool>`, `<Mcp>`, `<Skill>`, and `<FollowUp>` to their nearest Agent.

--- a/skills/aml-jsx/references/authoring-workflows.md
+++ b/skills/aml-jsx/references/authoring-workflows.md
@@ -40,30 +40,32 @@ Use nested Agents for dataflow dependencies. Do not use them merely for visual g
 
 ## Explicit parallel work
 
-JSX children resolve in authored order. Use `Promise.all()` inside an async component when branches are genuinely independent:
+JSX children resolve in authored order. Use `<Parallel>` when independent branch text should flow directly into the
+surrounding AML tree:
 
 ```tsx
-import { Agent, evaluate } from "@aml-jsx/sdk"
+import { Agent, Parallel } from "@aml-jsx/sdk"
 
-async function Review() {
-  const [correctness, maintainability] = await Promise.all([
-    evaluate(<Agent provider={OpenCode}>Find concrete correctness defects.</Agent>),
-    evaluate(<Agent provider={Codex}>Find proportionate maintainability improvements.</Agent>),
-  ])
-
+function Review() {
   return (
     <Agent provider={OpenCode}>
-      Correctness:
-      {correctness}
-      Maintainability:
-      {maintainability}
+      <Parallel>
+        <Agent provider={OpenCode}>Find concrete correctness defects.</Agent>
+        <Agent provider={Codex}>Find proportionate maintainability improvements.</Agent>
+      </Parallel>
       Produce one final review.
     </Agent>
   )
 }
 ```
 
-`evaluate()` requires an active AML component evaluation. Never call it as a detached top-level substitute for `runtime.evaluate()`.
+`<Parallel>` waits for every branch and its cleanup, preserves authored output order, and reports failures through
+`ParallelError.failures`. It does not retry, cancel healthy siblings after a failure, or roll back successful side
+effects. `maxConcurrentAgents` remains the Agent-session limit.
+
+Use `Promise.all([evaluate(...), evaluate(...)])` inside an async component when JavaScript needs named or
+schema-inferred branch values. `evaluate()` requires an active AML component evaluation; never call it as a detached
+top-level substitute for `runtime.evaluate()`.
 
 ## Structured output
 

--- a/skills/aml-jsx/references/providers-and-testing.md
+++ b/skills/aml-jsx/references/providers-and-testing.md
@@ -114,6 +114,7 @@ Test behavior that can regress:
 
 - Exact prompt and system assembly.
 - Authored ordering after parallel work.
+- Wait-for-all failure and cleanup behavior inside `<Parallel>`.
 - Structured output validation.
 - Tool and MCP isolation between sibling Agents.
 - Follow-up ordering within one session.


### PR DESCRIPTION
closes #9

## Description

Adds `<Parallel>` as AML's explicit tree-native concurrency boundary. Independent branches evaluate through the existing component-local `evaluate()` domain, settle before the boundary completes, and contribute text in authored order.

## What changed?

- Add `<Parallel>` and `ParallelError` to the public SDK surface.
- Recursively flatten child arrays while preserving Fragments as single ordered branches.
- Wait for every branch and its resource cleanup before returning or rejecting.
- Preserve authored output and failure ordering regardless of completion order.
- Keep `maxConcurrentAgents` as the only Agent-session concurrency limit.
- Support Agent-owned structured output as canonical JSON text inside branches.
- Exercise `<Parallel>` in the concurrency example and kitchen-sink smoke workflow.
- Document the contract across the specification, homepage, SDK reference, guides, and AML authoring skill.

## Verification

- Exercised genuinely overlapping branches and confirmed authored result ordering.
- Confirmed one or several failures produce indexed `ParallelError` entries only after healthy siblings and cleanup settle.
- Covered cancellation, runtime concurrency limits, nested boundaries, Context isolation, structured output, and descriptor ownership.
- Verified the homepage primitive entry and the generated `/docs/reference/primitives/parallel/` page.

> Branches wake at once
> Results return in their place
> Cleanup closes all
