### PR TITLE
feat(sdk): #30 add application observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,37 @@ workflows with `@aml-jsx/sdk`.
 | `defineWorkspaceProvider()`           | Defines a durable filesystem materialization provider.                                                           |
 | `createPersistentWorkspaceProvider()` | Builds revision persistence over a user-defined `WorkspaceStorageAdapter`.                                       |
 | `runtime.on()` / `runtime.once()`     | Subscribes to evaluation lifecycle and trace events.                                                             |
+| `withTraceSpan()`                     | Measures application-owned work inside the active function component.                                            |
+| `createTraceSummaryCollector()`       | Derives run-keyed, content-free summaries from the public trace stream.                                          |
+
+## Application observability
+
+AML automatically traces function components and runtime primitives, but a component span covers both the component
+call and resolution of its returned subtree. It cannot identify an application phase inside that component, such as
+validation, retrieval, or persistence. Use `withTraceSpan()` for that real lexical work:
+
+```tsx
+async function Review({ findings }: { findings: readonly Finding[] }) {
+  return await withTraceSpan("review.validate", async () => await validateFindings(findings))
+}
+```
+
+Application spans inherit the active component or application-span parent, close on success, error, or cancellation,
+and preserve the callback's result or thrown value. Calls outside an active function component, including detached work
+after it settles, are rejected. AML retains allocation of `runId`, `spanId`, and ancestry; applications supply only the
+span name and work to measure.
+
+`createTraceSummaryCollector()` consumes the same public immutable events as any other sink. Summaries are retrieved by
+explicit `runId`, so runtime reuse and overlapping evaluations never depend on a global latest result. They include
+evaluation status and wall duration, Agent session and turn timing, Tool and resource timing, named application spans,
+raw provider-reported usage entries, and Agent cleanup outcomes. Trace-consumer failures remain on the runtime's existing
+`onTraceError` channel. An empty `providerUsage` means the provider reported no usage; AML does not infer model-call
+counts, token fields, cache behavior, cost, or billing data.
+Each timing aggregate reports `count`, summed `totalDurationMs`, and `slowestMs` when present.
+Completed summaries remain available until the application calls `deleteRun(runId)`.
+
+See the [production-oriented observability cookbook](./examples/src/operations/trace-summaries.tsx) for custom phase
+timing, request-to-run correlation across concurrent evaluations, optional usage, cleanup, and trace-consumer reporting.
 
 ### Experimental APIs
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2085,7 +2085,7 @@ AML publishes one immutable, provider-neutral event stream:
 type AmlTraceAttribute = boolean | number | string | readonly string[]
 
 type AmlTraceSpanKind =
-  "evaluation" | "component" | "agent" | "system" | "skill" | "tool" | "loop" | "sandbox" | "workspace"
+  "application" | "evaluation" | "component" | "agent" | "system" | "skill" | "tool" | "loop" | "sandbox" | "workspace"
 
 type AmlTraceEvent =
   | {
@@ -2129,9 +2129,13 @@ interface TraceSink {
 }
 ```
 
-The event stream covers evaluation and component execution, Agent sessions and authored turns, System and Skill resolution, JavaScript Tool calls, committed Loop transitions, and Sandbox and Workspace scope lifecycles. Tool and MCP descriptor events describe capability grants; they do not claim that a provider completed a remote attachment lifecycle AML cannot observe. `capability.tool` identifies the JavaScript Tool `name`. `capability.mcp` identifies the server `name` and whether its `kind` is `named`, `stdio`, or `streamable-http`; it never includes transport configuration.
+The event stream covers evaluation and component execution, application-owned phases, Agent sessions and authored turns, System and Skill resolution, JavaScript Tool calls, committed Loop transitions, and Sandbox and Workspace scope lifecycles. Tool and MCP descriptor events describe capability grants; they do not claim that a provider completed a remote attachment lifecycle AML cannot observe. `capability.tool` identifies the JavaScript Tool `name`. `capability.mcp` identifies the server `name` and whether its `kind` is `named`, `stdio`, or `streamable-http`; it never includes transport configuration.
 
 Every event includes `runId`, `spanId`, a monotonically increasing evaluation-local `sequence`, and a Unix-millisecond `timestamp`. Nested events include `parentSpanId`. `span.end` reuses its `span.start` identity and reports non-negative elapsed milliseconds. An evaluation span is the root ancestor of every other span, including component-local `evaluate()` calls and concurrently scheduled Agents. Each lexical execution boundary is the direct parent of the subtree it evaluates: a component returning an Agent owns that Agent span, and Workspace, Sandbox, Loop, System, and Skill descendants remain beneath their corresponding spans.
+
+`withTraceSpan(name, operation)` measures application-owned work while a function component is active. AML allocates an `application` span beneath the active component or enclosing application span, preserves that ancestry across component-local `evaluate()`, Parallel branches, and concurrent asynchronous work, and closes the span on success, thrown failure, or cancellation. The callback result or thrown value passes through unchanged. Calls outside an active component or from detached work after that component settles are rejected. Applications provide only a non-empty normalized name and callback; AML retains ownership of trace identity and does not accept application metadata or content.
+
+`createTraceSummaryCollector()` is an ordinary consumer of the public trace stream. After an evaluation root span closes, `forRun(runId)` returns that explicit run's content-free summary; there is no global latest-run result. Summaries include evaluation status and wall duration, Agent session and authored-turn timing, Tool and resource timing, named application-span aggregates, raw provider-reported usage entries, and Agent cleanup outcomes. An empty usage list explicitly means no usage was reported; AML does not infer model-call counts, token fields, cache behavior, cost, or billing data. Cleanup and trace-consumer failures remain separate from workflow status, and `deleteRun(runId)` releases a retained completed summary.
 
 Agent spans begin when the runtime enters the authored Agent, before Agent-specific prop and Sandbox preflight, and include post-order request assembly plus the provider session. The runtime closes a successful Agent span only after its result enters the parent AML output channel. FollowUps remain inside that Agent span. `agent.turn` events are emitted in authored order at the provider handoff: the initial prompt is turn `1`, and the first FollowUp is turn `2`. A shared ACP structured-output repair prompt remains inside the final authored turn and emits its own ACP prompt events; it does not consume another authored-turn budget. Provider-internal reasoning, retries, tool loops, token accounting, and usage records are not part of the stable Slice 15 contract because the portable provider interface cannot observe them consistently.
 

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -192,6 +192,7 @@ export default defineConfig({
                 { slug: "docs/cookbook/production-job" },
                 { slug: "docs/cookbook/cli-process-safety" },
                 { slug: "docs/cookbook/observe-agent-activity" },
+                { slug: "docs/cookbook/application-observability" },
                 { slug: "docs/cookbook/codex-docker-s3" },
                 { slug: "docs/cookbook/structured-routing" },
               ],

--- a/apps/website/src/content/docs/docs/cookbook/application-observability.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/application-observability.mdx
@@ -1,0 +1,84 @@
+---
+title: Correlate application spans and run summaries
+description: Time application phases and retrieve content-free summaries for overlapping AML evaluations.
+---
+
+import { Aside, Badge } from "@astrojs/starlight/components"
+
+<Badge text="Deterministic" variant="success" />
+
+## Goal
+
+Measure a custom validation phase, correlate concurrent application requests to AML `runId` values, and retrieve one
+portable summary per completed evaluation without a global latest-run value.
+
+## Runtime and request correlation
+
+A shared runtime can execute several roots concurrently. Use application request context to associate the runtime's
+public `start` event with the request that initiated it:
+
+```tsx
+const requestContext = new AsyncLocalStorage<string>()
+const runIdsByRequest = new Map<string, string>()
+const summaries = createTraceSummaryCollector()
+const runtime = new AmlRuntime({
+  onTraceError: (error, event) => reportTraceFailure(error, event),
+  trace: summaries.trace,
+})
+
+runtime.on("start", event => {
+  const requestId = requestContext.getStore()
+  if (requestId !== undefined) runIdsByRequest.set(requestId, event.runId)
+})
+```
+
+This mapping remains explicit under overlap. It does not depend on trace arrival order or a mutable latest-run slot.
+
+## Time application work
+
+```tsx
+async function ReviewPhase({ candidates }: { readonly candidates: number }) {
+  return await withTraceSpan("review.validate", async () => `validated ${candidates}`)
+}
+```
+
+AML measures the callback beneath the active component. It does not add the callback's arguments, return value, or other
+application content to the trace.
+
+## Retrieve and release the summary
+
+```tsx
+async function evaluateRequest(requestId: string, candidates: number) {
+  try {
+    const value = await requestContext.run(requestId, async () =>
+      runtime.evaluate(<ReviewPhase candidates={candidates} />)
+    )
+    const runId = runIdsByRequest.get(requestId)
+    if (runId === undefined) throw new Error(`AML run identity was not captured for ${requestId}`)
+
+    const summary = summaries.forRun(runId)
+    if (summary === undefined) throw new Error(`AML summary was not completed for ${runId}`)
+    return { summary, value }
+  } finally {
+    const runId = runIdsByRequest.get(requestId)
+    if (runId !== undefined) summaries.deleteRun(runId)
+    runIdsByRequest.delete(requestId)
+  }
+}
+
+const [first, second] = await Promise.all([evaluateRequest("request-1", 3), evaluateRequest("request-2", 7)])
+```
+
+The collector retains completed summaries until `deleteRun(runId)`. `providerUsage: []` explicitly means no provider
+usage was reported. If ACP reports usage, the entry keeps that provider-owned JSON shape without inferred tokens, model
+calls, cache data, cost, or billing meaning.
+
+<Aside type="note" title="Telemetry failures are not workflow failures">
+  Handle sink failures with the runtime's existing `onTraceError` option; sink failures do not change the workflow
+  result. The collector reports runtime-emitted Agent cleanup outcomes in `cleanup` without rewriting evaluation status.
+</Aside>
+
+## Complete source
+
+The maintained [trace summary example](https://github.com/we-are-singular/aml/blob/main/examples/src/operations/trace-summaries.tsx)
+contains the complete imports and runnable deterministic flow.

--- a/apps/website/src/content/docs/docs/cookbook/index.mdx
+++ b/apps/website/src/content/docs/docs/cookbook/index.mdx
@@ -140,6 +140,11 @@ source links section.
     description="Build an ordered activity feed from Agent turn spans and unchanged ACP updates across two FollowUps."
   />
   <LinkCard
+    title="Correlate application observability"
+    href="/docs/cookbook/application-observability/"
+    description="Time custom phases and retrieve run-keyed summaries across overlapping evaluations."
+  />
+  <LinkCard
     title="Compose Codex, Docker, and S3"
     href="/docs/cookbook/codex-docker-s3/"
     description="Follow one production skeleton across a credentialed Agent, disposable container, and durable revisioned Workspace."
@@ -151,13 +156,14 @@ source links section.
   />
 </CardGrid>
 
-| Recipe                                                   | Status                                     | Needs                                                                                     | Best for                                                             |
-| -------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [Production job](/docs/cookbook/production-job/)         | Credentialed + deployment shape            | Node/ESM TSX runtime, OpenCode executable, model configuration, credentials, and a logger | Background jobs that need bounded execution and operational controls |
-| [CLI process safety](/docs/cookbook/cli-process-safety/) | Resource-backed, credential-free           | POSIX host, local Sandbox, CLI, and one terminal interrupt                                | Graceful signal handling and process-tree cleanup                    |
-| [Agent activity](/docs/cookbook/observe-agent-activity/) | Credentialed                               | OpenCode executable, model credentials, and an approved content-capturing terminal        | Understanding live ACP activity across Agent turns                   |
-| [Codex + Docker + S3](/docs/cookbook/codex-docker-s3/)   | Credentialed + container + durable storage | Codex ACP image, Docker, model credentials, S3 bucket, and AWS identity                   | Understanding the complete three-provider lifecycle                  |
-| [Structured routing](/docs/cookbook/structured-routing/) | Deterministic                              | Node, SDK/testing, `zod`, and an application-owned root directory                         | Safely turning model-shaped data into resource selection             |
+| Recipe                                                                 | Status                                     | Needs                                                                                     | Best for                                                             |
+| ---------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [Production job](/docs/cookbook/production-job/)                       | Credentialed + deployment shape            | Node/ESM TSX runtime, OpenCode executable, model configuration, credentials, and a logger | Background jobs that need bounded execution and operational controls |
+| [CLI process safety](/docs/cookbook/cli-process-safety/)               | Resource-backed, credential-free           | POSIX host, local Sandbox, CLI, and one terminal interrupt                                | Graceful signal handling and process-tree cleanup                    |
+| [Agent activity](/docs/cookbook/observe-agent-activity/)               | Credentialed                               | OpenCode executable, model credentials, and an approved content-capturing terminal        | Understanding live ACP activity across Agent turns                   |
+| [Application observability](/docs/cookbook/application-observability/) | Deterministic                              | Node, SDK, and application request context                                                | Custom phase timing and concurrent run correlation                   |
+| [Codex + Docker + S3](/docs/cookbook/codex-docker-s3/)                 | Credentialed + container + durable storage | Codex ACP image, Docker, model credentials, S3 bucket, and AWS identity                   | Understanding the complete three-provider lifecycle                  |
+| [Structured routing](/docs/cookbook/structured-routing/)               | Deterministic                              | Node, SDK/testing, `zod`, and an application-owned root directory                         | Safely turning model-shaped data into resource selection             |
 
 This recipe is intentionally provider-backed. It does not install OpenCode, provision credentials, define a deployment image, or make local execution safe for untrusted code. Treat the code as a composition-root pattern and inject the Sandbox/Workspace providers required by your deployment.
 

--- a/apps/website/src/content/docs/docs/observability.mdx
+++ b/apps/website/src/content/docs/docs/observability.mdx
@@ -58,6 +58,57 @@ aml run ./workflow.tsx --trace --capture-content
 
 Trace sinks are captured when the runtime is constructed. AML does not await a sink's returned promise. Synchronous throws and rejected promises go to `onTraceError` when configured; telemetry failure does not change the workflow result.
 
+## Application-owned spans
+
+Automatic component spans cover both a function component call and resolution of its returned subtree. They cannot
+isolate a narrower deterministic phase such as validation, retrieval, or persistence. Measure that work with
+`withTraceSpan()` inside an active function component:
+
+```tsx
+async function Review({ findings }: { findings: readonly Finding[] }) {
+  return await withTraceSpan("review.validate", async () => await validateFindings(findings))
+}
+```
+
+The runtime allocates an `application` span beneath the active component or enclosing application span. It closes the
+span on success, thrown failure, or cancellation without changing the callback result. Calls outside an active
+component, including detached calls after component settlement, fail. Nested calls remain correctly parented across
+`evaluate()`, `<Parallel>`, and concurrent async work.
+
+Applications supply only the span name and callback. They never supply trace identity, parent fields, metadata, or
+content.
+
+## Run summaries
+
+`createTraceSummaryCollector()` derives content-free summaries from the same public trace stream:
+
+```tsx
+const summaries = createTraceSummaryCollector()
+const runtime = new AmlRuntime({
+  onTraceError: (error, event) => reportTraceFailure(error, event),
+  trace: summaries.trace,
+})
+
+function summaryFor(runId: string) {
+  const summary = summaries.forRun(runId)
+  summaries.deleteRun(runId)
+  return summary
+}
+```
+
+`forRun()` requires an explicit evaluation `runId`; there is no latest-run API that becomes ambiguous when a runtime
+handles overlapping evaluations. Capture that identity from the public `start` event using the request-correlation
+pattern in the cookbook below. Completed summaries report evaluation status and wall duration, Agent session and turn
+timing, Tool and resource timing, named application spans, provider-reported usage entries, and Agent cleanup outcomes.
+Timing aggregates contain `count`, summed `totalDurationMs`, and `slowestMs` when at least one span was observed. The
+collector does not rewrite evaluation status. Trace-consumer failures remain separate on the runtime's existing
+`onTraceError` channel.
+
+`providerUsage` is empty when the provider reports no usage. When ACP supplies usage, AML retains the serialized JSON
+string rather than promising token fields that may not exist. A turn is one provider/ACP prompt request, not one model
+call. Summaries do not infer provider retries, cache behavior, costs, or billing data. See [Correlate application spans and run
+summaries](/docs/cookbook/application-observability/) for a concurrent production pattern.
+
 ## What an Agent trace represents
 
 AML traces the lifecycle it owns and the events that cross its ACP connection. One ACP `session/prompt` request is one **Agent turn**. It is not necessarily one model API call.

--- a/examples/src/operations/trace-summaries.tsx
+++ b/examples/src/operations/trace-summaries.tsx
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { AmlRuntime, createTraceSummaryCollector, withTraceSpan } from "@aml-jsx/sdk"
+
+const requestContext = new AsyncLocalStorage<string>()
+const runIdsByRequest = new Map<string, string>()
+const summaries = createTraceSummaryCollector()
+const runtime = new AmlRuntime({
+  onTraceError(error, event) {
+    console.error("AML trace sink failed", { error, sequence: event.sequence })
+  },
+  trace: summaries.trace,
+})
+
+runtime.on("start", event => {
+  const requestId = requestContext.getStore()
+  if (requestId !== undefined) runIdsByRequest.set(requestId, event.runId)
+})
+
+async function ReviewPhase({ candidates }: { readonly candidates: number }) {
+  return await withTraceSpan("review.validate", async () => `validated ${candidates}`)
+}
+
+/**
+ * Correlates overlapping application requests without relying on a latest run.
+ */
+async function evaluateRequest(requestId: string, candidates: number) {
+  try {
+    const value = await requestContext.run(
+      requestId,
+      async () => await runtime.evaluate(<ReviewPhase candidates={candidates} />)
+    )
+    const runId = runIdsByRequest.get(requestId)
+
+    if (runId === undefined) throw new Error(`AML run identity was not captured for request ${requestId}`)
+    const summary = summaries.forRun(runId)
+    if (summary === undefined) throw new Error(`AML summary was not completed for run ${runId}`)
+
+    return { summary, value }
+  } finally {
+    const runId = runIdsByRequest.get(requestId)
+    if (runId !== undefined) summaries.deleteRun(runId)
+    runIdsByRequest.delete(requestId)
+  }
+}
+
+const [first, second] = await Promise.all([evaluateRequest("request-1", 3), evaluateRequest("request-2", 7)])
+
+// providerUsage is [] when the active provider reports no usage. ACP usage is
+// retained as provider-reported JSON; AML does not reinterpret turns as calls,
+// invent token fields, calculate costs, or infer cache behavior.
+console.log(JSON.stringify([first, second], null, 2))

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -69,6 +69,17 @@ An unsandboxed `<Script />` runs as a trusted host process from `AmlRuntimeOptio
 
 The public factory names are `codexAgent()`, `copilotAgent()`, `glmAgent()`, `opencodeAgent()`, and `piAgent()`.
 
+## Application observability
+
+Use `withTraceSpan(name, operation)` inside a function component to time application work that automatic component and
+primitive spans cannot isolate. AML owns correlation identities and closes spans on success, failure, and cancellation.
+
+`createTraceSummaryCollector()` derives content-free summaries from public trace events. Read them with `forRun(runId)`;
+there is deliberately no concurrency-ambiguous latest-run API. Provider usage remains optional provider-reported JSON,
+Agent cleanup outcomes have their own field, and trace-consumer failures continue through `AmlRuntime.onTraceError`. The
+collector does not rewrite evaluation status. AML does not infer model calls, costs, cache behavior, or missing token
+fields.
+
 ## Coding agents
 
 Install AML's coding-agent skill for current workflow patterns, runtime semantics, providers, and testing guidance:

--- a/sdk/src/components/loop/loop-agent-selector.ts
+++ b/sdk/src/components/loop/loop-agent-selector.ts
@@ -5,7 +5,11 @@ import type { ContextScope } from "../context/context-scope.js"
 import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
 import { EvaluationError } from "../../core/evaluation-error.js"
 
-type NestedEvaluator = (value: AmlRenderable, schema: AmlModelSchema<unknown, unknown> | undefined) => Promise<unknown>
+type NestedEvaluator = (
+  value: AmlRenderable,
+  schema: AmlModelSchema<unknown, unknown> | undefined,
+  parentSpanId: string
+) => Promise<unknown>
 type ComponentInvoker = (
   componentType: Function,
   component: () => unknown,
@@ -76,7 +80,8 @@ export class LoopAgentSelector {
       schema: AmlModelSchema<unknown, unknown> | undefined,
       depth: number,
       activeAncestors: ReadonlySet<object>,
-      contextScope: ContextScope
+      contextScope: ContextScope,
+      parentSpanId: string
     ) => Promise<unknown>
   ): Promise<LoopAgentSelection> {
     const activeValues = new Set(activeAncestors)
@@ -205,8 +210,15 @@ export class LoopAgentSelector {
         const componentOutput = await invokeComponent(
           current.type,
           () => current.type(current.props),
-          async (nestedValue, nestedSchema) =>
-            await evaluateNested(nestedValue, nestedSchema, nodeDepth, new Set(activeValues), frame.contextScope),
+          async (nestedValue, nestedSchema, parentSpanId) =>
+            await evaluateNested(
+              nestedValue,
+              nestedSchema,
+              nodeDepth,
+              new Set(activeValues),
+              frame.contextScope,
+              parentSpanId
+            ),
           frame.contextScope
         )
 

--- a/sdk/src/core.ts
+++ b/sdk/src/core.ts
@@ -158,6 +158,8 @@ export type { AmlTraceIdentity } from "./core/trace-identity.js"
 
 // Provider-neutral observability contracts and the dependency-free console view.
 export { createConsoleTracer, type ConsoleTracerOptions } from "./observability/create-console-tracer.js"
+export { createTraceSummaryCollector, type TraceSummary } from "./observability/create-trace-summary-collector.js"
+export { withTraceSpan } from "./observability/with-trace-span.js"
 export type {
   AmlTraceAttribute,
   AmlTraceEvent,

--- a/sdk/src/core/aml-runtime.ts
+++ b/sdk/src/core/aml-runtime.ts
@@ -33,7 +33,7 @@ import type {
 } from "../components/workspace/workspace-provider.js"
 import type { WorkspaceProps } from "../components/workspace/workspace.js"
 import { AmlNode, type AmlRenderable } from "./aml-node.js"
-import { ComponentEvaluationContext } from "./component-evaluation-context.js"
+import { ComponentEvaluationContext, type ApplicationSpanRunner } from "./component-evaluation-context.js"
 import { AmlEventBus } from "./aml-event-bus.js"
 import type { AmlEventListener, AmlEventName } from "./aml-event-subscriber.js"
 import { EvaluationContext } from "./evaluation-context.js"
@@ -932,7 +932,9 @@ export class AmlRuntime {
                         component,
                         evaluateNested,
                         contextScope,
-                        (tool, input) => this.#callTool(tool, input, context, componentTrace)
+                        (tool, input) => this.#callTool(tool, input, context, componentTrace),
+                        componentTrace.spanId,
+                        this.#applicationSpanRunner(context, componentTrace.spanId)
                       )
                       context.endTraceSpan(componentSpan, "ok")
                       return output
@@ -941,7 +943,7 @@ export class AmlRuntime {
                       throw error
                     }
                   },
-                  async (nestedValue, nestedSchema, nestedDepth, nestedAncestors, nestedContextScope) => {
+                  async (nestedValue, nestedSchema, nestedDepth, nestedAncestors, nestedContextScope, parentSpanId) => {
                     const modelSchema = nestedSchema === undefined ? undefined : new ModelSchema(nestedSchema)
 
                     return await this.#evaluateInDomain(
@@ -950,7 +952,7 @@ export class AmlRuntime {
                       {
                         contextScope: nestedContextScope,
                         depth: nestedDepth,
-                        parentSpanId: trace.spanId,
+                        parentSpanId,
                         sandbox: frame.target.sandbox,
                         workspace: frame.target.workspace,
                       },
@@ -1358,7 +1360,7 @@ export class AmlRuntime {
           try {
             componentOutput = await ComponentEvaluationContext.invoke(
               () => current.type(current.props),
-              async (nestedValue, nestedSchema) => {
+              async (nestedValue, nestedSchema, parentSpanId) => {
                 context.signal.throwIfAborted()
 
                 // A nested schema is captured before its provider boundary.
@@ -1372,7 +1374,7 @@ export class AmlRuntime {
                   {
                     contextScope: frame.target.contextScope,
                     depth: nodeDepth,
-                    parentSpanId: trace.spanId,
+                    parentSpanId,
                     sandbox: frame.target.sandbox,
                     workspace: frame.target.workspace,
                   },
@@ -1381,7 +1383,9 @@ export class AmlRuntime {
                 )
               },
               frame.target.contextScope,
-              (tool, input) => this.#callTool(tool, input, context, trace)
+              (tool, input) => this.#callTool(tool, input, context, trace),
+              trace.spanId,
+              this.#applicationSpanRunner(context, trace.spanId)
             )
           } catch (error) {
             context.failTraceSpan(span, error)
@@ -1494,7 +1498,6 @@ export class AmlRuntime {
 
     return output.chunks.join("")
   }
-
   /**
    * Executes application-invoked Tools through the registered SDK port and the
    * same validation, snapshotting, cancellation, and trace path as Agents.
@@ -1522,6 +1525,31 @@ export class AmlRuntime {
       signal: context.signal,
       trace: parent,
     })
+  }
+
+  /**
+   * Creates a lexical application-span runner without exposing trace allocation.
+   */
+  #applicationSpanRunner(context: EvaluationContext, parentSpanId: string): ApplicationSpanRunner {
+    return async <Result>(
+      name: string,
+      operation: (childRunner: ApplicationSpanRunner, parentSpanId: string) => PromiseLike<Result> | Result
+    ): Promise<Result> => {
+      context.signal.throwIfAborted()
+      const trace = context.createObservationTrace(parentSpanId)
+      const span = context.startTraceSpan(trace, "application", name)
+
+      try {
+        const result = await operation(this.#applicationSpanRunner(context, trace.spanId), trace.spanId)
+        context.signal.throwIfAborted()
+        context.endTraceSpan(span, "ok")
+        return result
+      } catch (error) {
+        const failure = context.signal.aborted ? context.signal.reason : error
+        context.failTraceSpan(span, failure)
+        throw failure
+      }
+    }
   }
 }
 

--- a/sdk/src/core/component-evaluation-context.ts
+++ b/sdk/src/core/component-evaluation-context.ts
@@ -8,15 +8,31 @@ import type { AmlJsonValue } from "./aml-json-value.js"
 import type { AmlRenderable } from "./aml-node.js"
 import { EvaluationError } from "./evaluation-error.js"
 
-type NestedEvaluator = (value: AmlRenderable, schema: AmlModelSchema<unknown, unknown> | undefined) => Promise<unknown>
+type NestedEvaluator = (
+  value: AmlRenderable,
+  schema: AmlModelSchema<unknown, unknown> | undefined,
+  parentSpanId: string
+) => Promise<unknown>
 type ToolCaller = (tool: AmlTool<never, unknown>, input: unknown) => Promise<AmlJsonValue>
 
-interface ComponentEvaluationBinding {
+/** Runtime-owned application span capability carried by an active component. */
+export type ApplicationSpanRunner = <Result>(
+  name: string,
+  operation: (childRunner: ApplicationSpanRunner, parentSpanId: string) => PromiseLike<Result> | Result
+) => Promise<Result>
+
+interface ComponentEvaluationAuthority {
   active: boolean
-  contextScope: ContextScope | undefined
   evaluate: NestedEvaluator | undefined
   callTool: ToolCaller | undefined
   readonly pending: Set<Promise<unknown>>
+}
+
+interface ComponentEvaluationBinding {
+  readonly authority: ComponentEvaluationAuthority
+  contextScope: ContextScope | undefined
+  readonly parentSpanId: string
+  readonly runApplicationSpan: ApplicationSpanRunner
 }
 
 const AML_COMPONENT_EVALUATION_STORAGE = Symbol.for("@aml-jsx/sdk/component-evaluation-storage")
@@ -42,13 +58,13 @@ export class ComponentEvaluationContext {
   static evaluate(value: AmlRenderable, schema?: AmlModelSchema<unknown, unknown>): Promise<unknown> {
     const binding = ComponentEvaluationContext.#storage.getStore()
 
-    const evaluateNested = binding?.evaluate
+    const evaluateNested = binding?.authority.evaluate
 
-    if (binding === undefined || !binding.active || evaluateNested === undefined) {
+    if (binding === undefined || !binding.authority.active || evaluateNested === undefined) {
       throw new EvaluationError("evaluate() is only available while an AML component is active")
     }
 
-    return ComponentEvaluationContext.#track(binding, evaluateNested(value, schema))
+    return ComponentEvaluationContext.#track(binding.authority, evaluateNested(value, schema, binding.parentSpanId))
   }
 
   /**
@@ -56,13 +72,13 @@ export class ComponentEvaluationContext {
    */
   static callTool(tool: AmlTool<never, unknown>, input: unknown): Promise<AmlJsonValue> {
     const binding = ComponentEvaluationContext.#storage.getStore()
-    const callTool = binding?.callTool
+    const callTool = binding?.authority.callTool
 
-    if (binding === undefined || !binding.active || callTool === undefined) {
+    if (binding === undefined || !binding.authority.active || callTool === undefined) {
       throw new EvaluationError("Tools can only be called while an AML component is active")
     }
 
-    return ComponentEvaluationContext.#track(binding, callTool(tool, input))
+    return ComponentEvaluationContext.#track(binding.authority, callTool(tool, input))
   }
 
   /**
@@ -72,7 +88,7 @@ export class ComponentEvaluationContext {
     const binding = ComponentEvaluationContext.#storage.getStore()
     const contextScope = binding?.contextScope
 
-    if (binding === undefined || !binding.active || contextScope === undefined) {
+    if (binding === undefined || !binding.authority.active || contextScope === undefined) {
       throw new EvaluationError("useContext() is only available while an AML component is active")
     }
 
@@ -101,20 +117,48 @@ export class ComponentEvaluationContext {
   }
 
   /**
+   * Runs application work inside a runtime-owned child trace span.
+   */
+  static runApplicationSpan<Result>(name: string, operation: () => PromiseLike<Result> | Result): Promise<Result> {
+    const binding = ComponentEvaluationContext.#storage.getStore()
+
+    if (binding === undefined || !binding.authority.active) {
+      throw new EvaluationError("withTraceSpan() is only available while an AML component is active")
+    }
+
+    return ComponentEvaluationContext.#track(
+      binding.authority,
+      binding.runApplicationSpan(name, (childRunner, parentSpanId) =>
+        ComponentEvaluationContext.#storage.run(
+          { ...binding, parentSpanId, runApplicationSpan: childRunner },
+          operation
+        )
+      )
+    )
+  }
+
+  /**
    * Invokes one component exactly once with a scoped nested evaluator.
    */
   static async invoke(
     component: () => unknown,
     evaluateNested: NestedEvaluator,
     contextScope: ContextScope,
-    callTool: ToolCaller
+    callTool: ToolCaller,
+    parentSpanId: string,
+    runApplicationSpan: ApplicationSpanRunner
   ): Promise<unknown> {
-    const binding: ComponentEvaluationBinding = {
+    const authority: ComponentEvaluationAuthority = {
       active: true,
-      contextScope,
       evaluate: evaluateNested,
       callTool,
       pending: new Set(),
+    }
+    const binding: ComponentEvaluationBinding = {
+      authority,
+      contextScope,
+      parentSpanId,
+      runApplicationSpan,
     }
     let componentError: unknown
     let componentFailed = false
@@ -157,17 +201,17 @@ export class ComponentEvaluationContext {
       // revocation must mutate the shared binding rather than merely exit run().
       // Dropping the closure also prevents a detached timer from retaining the
       // complete runtime and evaluation domain after access has been revoked.
-      binding.active = false
+      authority.active = false
       binding.contextScope = undefined
-      binding.evaluate = undefined
-      binding.callTool = undefined
+      authority.evaluate = undefined
+      authority.callTool = undefined
     }
 
     // Promise.all() rejects before its remaining branches settle. Join only the
     // still-active nested evaluations before an enclosing resource scope can
     // release underneath them.
-    const pendingResults = await Promise.allSettled([...binding.pending])
-    binding.pending.clear()
+    const pendingResults = await Promise.allSettled([...authority.pending])
+    authority.pending.clear()
     const pendingErrors = pendingResults
       .filter((result): result is PromiseRejectedResult => result.status === "rejected")
       .map(result => result.reason as unknown)
@@ -199,14 +243,14 @@ export class ComponentEvaluationContext {
   /**
    * Keeps started component work alive through enclosing resource cleanup.
    */
-  static #track<Result>(binding: ComponentEvaluationBinding, pending: Promise<Result>): Promise<Result> {
-    binding.pending.add(pending)
+  static #track<Result>(authority: ComponentEvaluationAuthority, pending: Promise<Result>): Promise<Result> {
+    authority.pending.add(pending)
 
     // Both handlers observe rejection immediately without changing the Promise
     // returned to application code or manufacturing an unhandled Promise.
     void pending.then(
-      () => binding.pending.delete(pending),
-      () => binding.pending.delete(pending)
+      () => authority.pending.delete(pending),
+      () => authority.pending.delete(pending)
     )
 
     return pending

--- a/sdk/src/observability/create-trace-summary-collector.ts
+++ b/sdk/src/observability/create-trace-summary-collector.ts
@@ -1,0 +1,110 @@
+import type { AmlTraceSpanEndEvent } from "./trace-event.js"
+import type { TraceSink } from "./trace-sink.js"
+
+interface TraceSpanAggregate {
+  readonly count: number
+  readonly slowestMs?: number
+  readonly totalDurationMs: number
+}
+
+interface TraceCleanupOutcome {
+  readonly durationMs: number
+  readonly status: "error" | "ok"
+}
+
+/** Content-free measurements derived from one completed evaluation trace. */
+export interface TraceSummary {
+  readonly agents: {
+    readonly sessions: TraceSpanAggregate
+    readonly turns: TraceSpanAggregate
+  }
+  readonly applicationSpans: Readonly<Record<string, TraceSpanAggregate>>
+  readonly cleanup: readonly TraceCleanupOutcome[]
+  readonly durationMs: number
+  readonly providerUsage: readonly string[]
+  readonly resources: {
+    readonly sandboxes: TraceSpanAggregate
+    readonly scripts: TraceSpanAggregate
+    readonly workspaces: TraceSpanAggregate
+  }
+  readonly runId: string
+  readonly status: "error" | "ok"
+  readonly tools: TraceSpanAggregate
+}
+
+/** Derives run-keyed summaries from public immutable trace events. */
+export function createTraceSummaryCollector() {
+  const active = new Map<string, AmlTraceSpanEndEvent[]>()
+  const completed = new Map<string, TraceSummary>()
+
+  const trace: TraceSink = event => {
+    if (event.type !== "span.end") return
+
+    const spans = active.get(event.runId) ?? []
+    spans.push(event)
+
+    if (event.kind === "evaluation") {
+      completed.set(event.runId, summarize(event, spans))
+      active.delete(event.runId)
+    } else {
+      active.set(event.runId, spans)
+    }
+  }
+
+  return Object.freeze({
+    deleteRun(runId: string) {
+      return completed.delete(runId)
+    },
+    forRun(runId: string) {
+      return completed.get(runId)
+    },
+    trace,
+  })
+}
+
+function summarize(root: AmlTraceSpanEndEvent, spans: readonly AmlTraceSpanEndEvent[]): TraceSummary {
+  const applicationNames = new Set(spans.filter(span => span.kind === "application").map(span => span.name))
+  const applicationSpans = Object.fromEntries(
+    [...applicationNames].map(name => [
+      name,
+      aggregate(spans.filter(span => span.kind === "application" && span.name === name)),
+    ])
+  )
+
+  const agentSpans = spans.filter(span => span.kind === "agent")
+  const turns = agentSpans.filter(span => span.name === "agent.turn")
+
+  return Object.freeze({
+    agents: Object.freeze({
+      sessions: aggregate(agentSpans.filter(span => span.name === "agent.session")),
+      turns: aggregate(turns),
+    }),
+    applicationSpans: Object.freeze(applicationSpans),
+    cleanup: Object.freeze(
+      agentSpans
+        .filter(span => span.name === "agent.cleanup")
+        .map(span => Object.freeze({ durationMs: span.durationMs, status: span.status }))
+    ),
+    durationMs: root.durationMs,
+    providerUsage: Object.freeze(
+      turns.flatMap(span => (typeof span.attributes.usage === "string" ? [span.attributes.usage] : []))
+    ),
+    resources: Object.freeze({
+      sandboxes: aggregate(spans.filter(span => span.kind === "sandbox")),
+      scripts: aggregate(spans.filter(span => span.kind === "script")),
+      workspaces: aggregate(spans.filter(span => span.kind === "workspace")),
+    }),
+    runId: root.runId,
+    status: root.status,
+    tools: aggregate(spans.filter(span => span.kind === "tool")),
+  })
+}
+
+function aggregate(spans: readonly AmlTraceSpanEndEvent[]): TraceSpanAggregate {
+  const totalDurationMs = spans.reduce((total, span) => total + span.durationMs, 0)
+  return Object.freeze({
+    count: spans.length,
+    ...(spans.length === 0 ? {} : { slowestMs: Math.max(...spans.map(span => span.durationMs)) }),
+    totalDurationMs,
+  })
+}

--- a/sdk/src/observability/trace-event.ts
+++ b/sdk/src/observability/trace-event.ts
@@ -12,6 +12,7 @@ export type AmlTraceAttribute = boolean | number | string | readonly string[]
  * Execution boundaries represented by paired start and end events.
  */
 export type AmlTraceSpanKind =
+  | "application"
   | "evaluation"
   | "component"
   | "agent"

--- a/sdk/src/observability/with-trace-span.ts
+++ b/sdk/src/observability/with-trace-span.ts
@@ -1,0 +1,17 @@
+import { ComponentEvaluationContext } from "../core/component-evaluation-context.js"
+
+/**
+ * Measures application-owned work beneath the currently active AML component.
+ * The callback result and thrown value pass through unchanged.
+ */
+export function withTraceSpan<Result>(name: string, operation: () => PromiseLike<Result> | Result): Promise<Result> {
+  if (typeof name !== "string" || name.length === 0 || name.trim() !== name) {
+    throw new TypeError("withTraceSpan name must be a non-empty normalized string")
+  }
+
+  if (typeof operation !== "function") {
+    throw new TypeError("withTraceSpan operation must be a function")
+  }
+
+  return ComponentEvaluationContext.runApplicationSpan(name, operation)
+}

--- a/sdk/tests/application-observability.test.tsx
+++ b/sdk/tests/application-observability.test.tsx
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest"
+
+import { Parallel } from "../src/components/parallel/parallel.js"
+import { AmlRuntime } from "../src/core/aml-runtime.js"
+import { evaluate } from "../src/core/evaluate.js"
+import { createTraceSummaryCollector } from "../src/observability/create-trace-summary-collector.js"
+import type { AmlTraceEvent } from "../src/observability/trace-event.js"
+import { withTraceSpan } from "../src/observability/with-trace-span.js"
+
+describe("application observability", () => {
+  it("nests application spans under components and concurrent lexical work", async () => {
+    const events: AmlTraceEvent[] = []
+
+    function Evaluated({ name }: { readonly name: string }) {
+      return name
+    }
+
+    async function Lane({ name }: { readonly name: string }) {
+      return await withTraceSpan(`${name}.outer`, async () => {
+        const [nested, evaluated] = await Promise.all([
+          withTraceSpan(`${name}.inner`, async () => withTraceSpan(`${name}.deep`, async () => name)),
+          evaluate(<Evaluated name={name} />),
+        ])
+        return `${nested}${evaluated}`
+      })
+    }
+
+    function Workflow() {
+      return (
+        <Parallel>
+          <Lane name="first" />
+          <Lane name="second" />
+        </Parallel>
+      )
+    }
+
+    await expect(new AmlRuntime({ trace: event => events.push(event) }).evaluate(<Workflow />)).resolves.toBe(
+      "firstfirstsecondsecond"
+    )
+
+    const starts = events.filter(event => event.type === "span.start")
+    for (const lane of ["first", "second"]) {
+      const component = starts.find(
+        event =>
+          event.kind === "component" &&
+          event.name === "Lane" &&
+          starts.some(child => child.parentSpanId === event.spanId && child.name === `${lane}.outer`)
+      )
+      const outer = starts.find(event => event.kind === "application" && event.name === `${lane}.outer`)
+      const inner = starts.find(event => event.kind === "application" && event.name === `${lane}.inner`)
+      const deep = starts.find(event => event.kind === "application" && event.name === `${lane}.deep`)
+
+      expect(outer?.parentSpanId).toBe(component?.spanId)
+      expect(inner?.parentSpanId).toBe(outer?.spanId)
+      expect(deep?.parentSpanId).toBe(inner?.spanId)
+      expect(starts.some(event => event.name === "Evaluated" && event.parentSpanId === outer?.spanId)).toBe(true)
+    }
+  })
+
+  it("closes application spans on success, thrown values, and cancellation", async () => {
+    const events: AmlTraceEvent[] = []
+    const controller = new AbortController()
+    const thrown = { reason: "preserved" }
+
+    async function Failure() {
+      await withTraceSpan("successful", () => "ok")
+      await withTraceSpan("failed", () => {
+        throw thrown
+      })
+      return "unreachable"
+    }
+
+    await expect(new AmlRuntime({ trace: event => events.push(event) }).evaluate(<Failure />)).rejects.toBe(thrown)
+
+    async function Cancelled() {
+      return await withTraceSpan("cancelled", async () => {
+        controller.abort(new Error("stop"))
+        await Promise.resolve()
+        return "late"
+      })
+    }
+
+    await expect(
+      new AmlRuntime({ trace: event => events.push(event) }).evaluate(<Cancelled />, { signal: controller.signal })
+    ).rejects.toThrow("stop")
+
+    expect(events.find(event => event.type === "span.end" && event.name === "successful")).toMatchObject({
+      status: "ok",
+    })
+    expect(events.find(event => event.type === "span.end" && event.name === "failed")).toMatchObject({
+      status: "error",
+    })
+    expect(events.find(event => event.type === "span.end" && event.name === "cancelled")).toMatchObject({
+      status: "error",
+    })
+  })
+
+  it("rejects calls outside an active component or after it settles", async () => {
+    let detached: (() => void) | undefined
+
+    function Workflow() {
+      detached = () => void withTraceSpan("late", () => undefined)
+      return "done"
+    }
+
+    expect(() => withTraceSpan("outside", () => undefined)).toThrow(
+      "withTraceSpan() is only available while an AML component is active"
+    )
+    await new AmlRuntime().evaluate(<Workflow />)
+    expect(detached).toThrow("withTraceSpan() is only available while an AML component is active")
+  })
+
+  it("isolates concurrent runtime evaluations and summarizes explicit run IDs", async () => {
+    const summaries = createTraceSummaryCollector()
+    const runtime = new AmlRuntime({ trace: summaries.trace })
+    const runIds: string[] = []
+    runtime.on("start", event => {
+      runIds.push(event.runId)
+    })
+
+    async function Workflow({ name }: { readonly name: string }) {
+      return await withTraceSpan(name, async () => name)
+    }
+
+    await Promise.all([runtime.evaluate(<Workflow name="first" />), runtime.evaluate(<Workflow name="second" />)])
+
+    expect(runIds).toHaveLength(2)
+    expect(runIds[0]).not.toBe(runIds[1])
+    expect(summaries.forRun(runIds[0] ?? "")).toMatchObject({
+      applicationSpans: { first: { count: 1 } },
+      providerUsage: [],
+      status: "ok",
+    })
+    expect(summaries.forRun(runIds[1] ?? "")).toMatchObject({
+      applicationSpans: { second: { count: 1 } },
+      providerUsage: [],
+      status: "ok",
+    })
+  })
+
+  it("keeps provider usage raw and cleanup separate from evaluation status", () => {
+    const summaries = createTraceSummaryCollector()
+    const base = { attributes: {}, runId: "run", timestamp: 1 }
+
+    summaries.trace({
+      ...base,
+      attributes: { usage: '{"inputTokens":10,"outputTokens":4}' },
+      durationMs: 3,
+      kind: "agent",
+      name: "agent.turn",
+      parentSpanId: "session",
+      sequence: 1,
+      spanId: "turn",
+      status: "ok",
+      type: "span.end",
+    })
+    summaries.trace({
+      ...base,
+      durationMs: 1,
+      kind: "agent",
+      name: "agent.cleanup",
+      parentSpanId: "session",
+      sequence: 2,
+      spanId: "cleanup",
+      status: "error",
+      type: "span.end",
+    })
+    summaries.trace({
+      ...base,
+      durationMs: 6,
+      kind: "agent",
+      name: "agent.session",
+      parentSpanId: "agent",
+      sequence: 3,
+      spanId: "session",
+      status: "error",
+      type: "span.end",
+    })
+    summaries.trace({
+      ...base,
+      durationMs: 8,
+      kind: "evaluation",
+      name: "evaluate",
+      sequence: 4,
+      spanId: "root",
+      status: "ok",
+      type: "span.end",
+    })
+
+    expect(summaries.forRun("run")).toMatchObject({
+      cleanup: [{ status: "error" }],
+      providerUsage: ['{"inputTokens":10,"outputTokens":4}'],
+      status: "ok",
+    })
+  })
+})


### PR DESCRIPTION
closes #30

## What changed?

- Add `withTraceSpan(name, operation)` for application-owned phases inside active AML components, with runtime-owned ancestry and lifecycle.
- Add `createTraceSummaryCollector()` for explicit run-keyed, content-free summaries derived from the public trace stream.
- Document application observability in the SDK, root README, SPEC, website, and production cookbook.

## Verification

- Covered nested, parallel, concurrent-root, success, thrown-error, cancellation, and post-settlement span behavior.
- Covered explicit run correlation, conservative provider usage, and separate cleanup outcomes.

> Phases find their names
> Traces keep each run apart
> Safe facts remain
