### PR TITLE
fix(agent-opencode): #36 preserve disabled native tools

### DIFF
--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -32,29 +32,29 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
     const configuration: NonNullable<AcpAgentLaunch["configuration"]>[number][] = []
     const initialPromptSections: string[] = []
-    const tools: Record<string, boolean> = { "*": true }
+    const deniedTools: Record<string, false> = {}
     const permission: Record<string, "allow" | "deny"> = { "*": "allow" }
     const inheritedPermission: Record<string, "deny"> = {}
 
     // OpenCode exposes more granular controls than ACP. Translate the portable
     // request here while the outer Sandbox remains the hard boundary.
     if (context.request.permissions.filesystem === "read-only") {
-      tools.edit = false
-      tools.write = false
+      deniedTools.edit = false
+      deniedTools.write = false
       permission.edit = "deny"
       permission.write = "deny"
       inheritedPermission.edit = "deny"
     }
 
     if (!context.request.permissions.shell) {
-      tools.bash = false
+      deniedTools.bash = false
       permission.bash = "deny"
       inheritedPermission.bash = "deny"
     }
 
     if (!context.request.permissions.network) {
-      tools.webfetch = false
-      tools.websearch = false
+      deniedTools.webfetch = false
+      deniedTools.websearch = false
       permission.webfetch = "deny"
       permission.websearch = "deny"
       inheritedPermission.webfetch = "deny"
@@ -75,6 +75,16 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
     }
 
     const configuredAgents = configTable(this.#options.config.agent)
+    const configuredAmlAgent = configTable(configuredAgents.aml)
+    const configuredAmlTools = configTable(configuredAmlAgent.tools) as Readonly<Record<string, boolean>>
+    // Preserve native Tool choices from both OpenCode config layers, then let
+    // AML's portable permission denials remain the final authority.
+    const tools: Record<string, boolean> = {
+      "*": true,
+      ...this.#options.config.tools,
+      ...configuredAmlTools,
+      ...deniedTools,
+    }
     const configuredPermission =
       typeof this.#options.config.permission === "string"
         ? { "*": this.#options.config.permission }

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -231,7 +231,7 @@ describe("opencodeAgent()", () => {
     expect(prompts[1]).toContain('"proof"')
   })
 
-  it("maps restrictive Agent permissions into OpenCode's native controls", async () => {
+  it("merges caller-disabled native tools before portable permission denials", async () => {
     let config: Record<string, unknown> | undefined
     const sandboxProvider = new DeterministicSandboxProvider({
       exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
@@ -240,7 +240,13 @@ describe("opencodeAgent()", () => {
         return completedProcess()
       },
     })
-    const provider = opencodeAgent({ config: { permission: { bash: "allow", question: "deny" } } })
+    const provider = opencodeAgent({
+      config: {
+        agent: { aml: { tools: { edit: true, question: false, write: true } } },
+        permission: { bash: "allow", question: "deny" },
+        tools: { question: true, task: false },
+      },
+    })
 
     await expect(
       new AmlRuntime({ agentProvider: provider }).evaluate(
@@ -266,6 +272,8 @@ describe("opencodeAgent()", () => {
             "*": true,
             bash: false,
             edit: false,
+            question: false,
+            task: false,
             webfetch: false,
             websearch: false,
             write: false,
@@ -281,7 +289,6 @@ describe("opencodeAgent()", () => {
       },
     })
     expect(config).not.toHaveProperty("agent.aml.permission.task")
-    expect(config).not.toHaveProperty("agent.aml.tools.task")
     expect(config).not.toHaveProperty("instructions")
     expect((config.agent as { aml: unknown }).aml).not.toHaveProperty("prompt")
   })


### PR DESCRIPTION
closes #36

## Description

Preserve caller-disabled native OpenCode tools on AML's generated primary Agent while keeping portable AML permission denials authoritative.

## What changed?

- Merge top-level OpenCode tool configuration into `agent.aml.tools`.
- Apply explicit `agent.aml.tools` choices after top-level choices.
- Apply AML filesystem, shell, and network denials last.
- Cover the emitted `OPENCODE_CONFIG_CONTENT` merge and precedence behavior.

## Verification

- Confirmed `tools.task: false` remains disabled on the generated AML Agent.
- Confirmed explicit AML Agent tool choices override top-level choices.
- Confirmed read-only filesystem access still disables OpenCode's `edit` and `write` tools.

> Native tools stay still
> Portable limits hold fast
> The parent keeps control
