### PR TITLE
test(sandbox): wait for process group reaping

### DIFF
--- a/providers/sandboxes/local/tests/local-sandbox.test.tsx
+++ b/providers/sandboxes/local/tests/local-sandbox.test.tsx
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promis
 import os from "node:os"
 import path from "node:path"
 
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { AmlRuntime, Sandbox, Script, type SandboxAcquireRequest, Workspace } from "@aml-jsx/sdk"
 import { DeterministicWorkspaceProvider, sandboxProviderConformance } from "@aml-jsx/sdk/testing"
@@ -157,7 +157,12 @@ describe("localSandbox()", () => {
     await spawned.kill()
     await spawned.wait().catch(() => undefined)
     await reader.cancel()
-    expect(() => process.kill(childPid, 0)).toThrow(expect.objectContaining({ code: "ESRCH" }))
+    // The killed grandchild can briefly remain as a zombie until the runner's
+    // init process reaps it, during which signal 0 still reports that PID.
+    await vi.waitFor(
+      () => expect(() => process.kill(childPid, 0)).toThrow(expect.objectContaining({ code: "ESRCH" })),
+      { timeout: 1_000 }
+    )
     await lease.release()
   })
 


### PR DESCRIPTION
## Description

Stabilize the local sandbox process-group cleanup test when a killed grandchild briefly remains as a zombie before the CI runner reaps it.

## What changed?

- Wait up to one second for the killed grandchild PID to disappear.
- Document why signal 0 can temporarily report an already-dead process as present.
- Preserve the assertion that descendants must not survive process-group cleanup.

## Verification

- Repeated the exact process-group cleanup scenario 25 consecutive times.
- Exercised all local sandbox behaviors, including spawned-process lifecycle and cleanup.

> Killed child processes
> Runners reap in their own time
> Tests await the truth
