### PR TITLE
docs: document public sdk and provider contracts

### DIFF
--- a/providers/agents/codex/src/codex-agent.ts
+++ b/providers/agents/codex/src/codex-agent.ts
@@ -13,21 +13,94 @@ export type CodexConfigValue =
   | string
   | null
   | readonly CodexConfigValue[]
-  | Readonly<{ readonly [key: string]: CodexConfigValue }>
+  | Readonly<{
+      /** Stores one nested Codex configuration value under its authored key. */
+      readonly [key: string]: CodexConfigValue
+    }>
 
+/**
+ * Configures the maintained Codex ACP adapter and the Codex process it launches.
+ *
+ * Options are validated and snapshotted when {@link codexAgent} is called, so
+ * later mutations to arrays or objects do not alter the provider.
+ */
 export interface CodexAgentOptions {
+  /**
+   * API key written to `CODEX_API_KEY` for the launched session.
+   *
+   * Omit to use credentials from `env` or the adapter's own supported flow. An
+   * explicit value overrides `env.CODEX_API_KEY` and selects ACP's `api-key`
+   * authentication method.
+   */
   readonly apiKey?: string
+
+  /**
+   * Arguments appended to the ACP adapter command exactly as supplied.
+   *
+   * Defaults to `[]`. Entries may be empty but cannot contain null bytes.
+   */
   readonly args?: readonly string[]
+
+  /**
+   * ACP adapter executable or application-owned launcher.
+   *
+   * Defaults to `"codex-acp"`. AML does not install or resolve the adapter.
+   */
   readonly command?: string
+
+  /**
+   * Codex executable path exposed to the adapter as `CODEX_PATH`.
+   *
+   * Defaults to `"codex"`. This does not replace the outer `command` that
+   * starts the ACP adapter.
+   */
   readonly codexPathOverride?: string
+
+  /**
+   * Base Codex configuration serialized into `CODEX_CONFIG`.
+   *
+   * Defaults to `{}` and must be JSON-serializable. The effective model,
+   * reasoning effort, and AML system instructions are applied afterward and
+   * therefore override the corresponding base keys when present.
+   */
   readonly config?: Readonly<Record<string, CodexConfigValue>>
+
+  /**
+   * Additional environment variables for the launched adapter.
+   *
+   * Defaults to `{}`. AML-owned session isolation and launch variables are
+   * written after this object and cannot be overridden through it.
+   */
   readonly env?: Readonly<Record<string, string>>
+
+  /**
+   * Provider-level model fallback.
+   *
+   * Omit to let Codex select its configured default. An `<Agent model>` prop
+   * takes precedence for that Agent session.
+   */
   readonly model?: string
+
+  /**
+   * Provider-native value written to Codex `model_reasoning_effort`.
+   *
+   * Omitted by default. AML validates only that the string is normalized and
+   * forwards it without maintaining an allowlist.
+   */
   readonly reasoningEffort?: string
+
+  /**
+   * Fallback working directory for host execution.
+   *
+   * Omit to inherit the application directory. An active Sandbox supplies the
+   * effective directory instead.
+   */
   readonly workingDirectory?: string
 }
 
+/** Agent provider returned by {@link codexAgent}. */
 export interface CodexAgentProvider extends AgentProvider {
+  /** Stable provider identifier reported in Agent requests and traces. */
   readonly name: "codex"
 }
 
@@ -96,6 +169,9 @@ class CodexProfile implements AcpAgentProfile<"codex"> {
  *
  * The trusted host or selected Sandbox must contain `codex-acp` or the
  * configured command. AML never installs the adapter implicitly.
+ * Configuration is validated and captured before any process or Sandbox work.
+ *
+ * @param options Adapter command, credentials, Codex configuration, and defaults.
  */
 export function codexAgent(options: CodexAgentOptions = {}): Readonly<CodexAgentProvider> {
   const profile = new CodexProfile(captureOptions(options))

--- a/providers/agents/copilot/src/copilot-agent.ts
+++ b/providers/agents/copilot/src/copilot-agent.ts
@@ -10,15 +10,55 @@ const AUTH_TOKEN_ENVIRONMENT_VARIABLES = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "G
 
 /** Configures GitHub Copilot CLI's native ACP server. */
 export interface CopilotAgentOptions {
+  /**
+   * Extra Copilot arguments inserted before AML-owned ACP, isolation, model,
+   * and permission flags. Defaults to `[]`; entries cannot contain null bytes.
+   */
   readonly args?: readonly string[]
+
+  /**
+   * Copilot CLI executable or application-owned launcher.
+   *
+   * Defaults to `"copilot"`. AML does not install the CLI.
+   */
   readonly command?: string
+
+  /**
+   * Additional environment variables, including optional Copilot credentials.
+   *
+   * Defaults to `{}`. Explicit `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or
+   * `GITHUB_TOKEN` values here take source precedence over the local process
+   * environment. AML-owned private-state variables are applied afterward.
+   */
   readonly env?: Readonly<Record<string, string>>
+
+  /**
+   * Provider-level model fallback.
+   *
+   * Defaults to `"auto"`, allowing Copilot to choose for the authenticated
+   * account. An `<Agent model>` prop takes precedence.
+   */
   readonly model?: string
+
+  /**
+   * Provider-native value passed through Copilot's reasoning-effort flag.
+   *
+   * Omitted by default. AML validates the normalized string but does not
+   * maintain an allowlist of values supported by a particular CLI version.
+   */
   readonly reasoningEffort?: string
+
+  /**
+   * Fallback working directory when no active Sandbox supplies one.
+   *
+   * Omit to use the application working directory.
+   */
   readonly workingDirectory?: string
 }
 
+/** Agent provider returned by {@link copilotAgent}. */
 export interface CopilotAgentProvider extends AgentProvider {
+  /** Stable provider identifier reported in Agent requests and traces. */
   readonly name: "copilot"
 }
 
@@ -142,6 +182,12 @@ class CopilotAcpProfile implements AcpAgentProfile<"copilot"> {
  * The selected host or Sandbox must contain `copilot` or the configured
  * command. Authentication follows the launched process environment; AML does
  * not import the interactive user's Copilot configuration.
+ *
+ * Options are validated and captured before process or Sandbox acquisition.
+ * AML maps portable permission denials into Copilot flags, while the enclosing
+ * Sandbox remains the process-level enforcement boundary.
+ *
+ * @param options CLI command, environment, model, and working-directory defaults.
  */
 export function copilotAgent(options: CopilotAgentOptions = {}): Readonly<CopilotAgentProvider> {
   const profile = new CopilotAcpProfile(captureOptions(options))

--- a/providers/agents/glm/src/glm-agent.ts
+++ b/providers/agents/glm/src/glm-agent.ts
@@ -6,21 +6,72 @@ import {
   type AgentProvider,
 } from "@aml-jsx/sdk"
 
+/**
+ * Configures the community-maintained GLM ACP adapter and Coding Plan request.
+ */
 export interface GlmAgentOptions {
-  /** Z.AI Coding Plan API key; billed against plan quota, not pay-as-you-go API credit. */
+  /**
+   * Z.AI Coding Plan API key written to `Z_AI_API_KEY`.
+   *
+   * Omit to supply `env.Z_AI_API_KEY`. An explicit value takes precedence and
+   * advertises the adapter's `z-ai-api-key` authentication method.
+   */
   readonly apiKey?: string
+
+  /**
+   * Arguments appended to the adapter command exactly as supplied.
+   *
+   * Defaults to `[]`; entries cannot contain null bytes.
+   */
   readonly args?: readonly string[]
-  /** Overrides the GLM Coding Plan endpoint used by the adapter. */
+
+  /**
+   * Coding Plan endpoint written to `ACP_GLM_BASE_URL`.
+   *
+   * Omit to use the adapter's default endpoint.
+   */
   readonly baseUrl?: string
+
+  /**
+   * ACP adapter executable or application-owned launcher.
+   *
+   * Defaults to `"glm-acp-agent"`. AML does not install the adapter.
+   */
   readonly command?: string
+
+  /**
+   * Additional environment variables for the adapter process.
+   *
+   * Defaults to `{}`. AML-owned key, endpoint, model, token-limit, and private
+   * session variables are written afterward and take precedence when present.
+   */
   readonly env?: Readonly<Record<string, string>>
-  /** Upper bound for one model completion; the adapter default is 8192 tokens. */
+
+  /**
+   * Positive safe-integer completion limit written to `ACP_GLM_MAX_TOKENS`.
+   *
+   * Omit to use the adapter default, currently 8192 tokens.
+   */
   readonly maxTokens?: number
+
+  /**
+   * Provider-level model fallback written to `ACP_GLM_MODEL`.
+   *
+   * Omit to use the adapter's default. An `<Agent model>` prop takes precedence.
+   */
   readonly model?: string
+
+  /**
+   * Fallback working directory when no active Sandbox supplies one.
+   *
+   * Omit to use the application working directory.
+   */
   readonly workingDirectory?: string
 }
 
+/** Agent provider returned by {@link glmAgent}. */
 export interface GlmAgentProvider extends AgentProvider {
+  /** Stable provider identifier reported in Agent requests and traces. */
   readonly name: "glm"
 }
 
@@ -83,6 +134,11 @@ class GlmAcpProfile implements AcpAgentProfile<"glm"> {
  * configured command, plus a Z.AI Coding Plan API key. AML never installs the
  * adapter implicitly. This adapter is community-maintained and is not the
  * Z.ai ZCode harness; ZCode has no ACP implementation today.
+ *
+ * The adapter does not expose portable shell or network restrictions; use an
+ * enforcing Sandbox when those permissions are security requirements.
+ *
+ * @param options Adapter command, Coding Plan settings, environment, and defaults.
  */
 export function glmAgent(options: GlmAgentOptions = {}): Readonly<GlmAgentProvider> {
   const profile = new GlmAcpProfile(captureOptions(options))

--- a/providers/agents/opencode/src/index.ts
+++ b/providers/agents/opencode/src/index.ts
@@ -1,4 +1,4 @@
 // Configured provider factory and lifecycle contract.
 export { opencodeAgent, type OpenCodeAgentProvider } from "./opencode-agent.js"
 export type { OpenCodeAgentOptions } from "./opencode-agent-options.js"
-export type { Config as OpenCodeConfig } from "@opencode-ai/sdk/v2"
+export type { OpenCodeConfig } from "./opencode-config.js"

--- a/providers/agents/opencode/src/opencode-agent-options.ts
+++ b/providers/agents/opencode/src/opencode-agent-options.ts
@@ -1,14 +1,53 @@
-import type { Config } from "@opencode-ai/sdk/v2"
+import type { OpenCodeConfig } from "./opencode-config.js"
 
 /**
  * Configures the OpenCode ACP profile without selecting another lifecycle.
  */
 export interface OpenCodeAgentOptions {
+  /**
+   * Arguments appended after AML's `acp --pure --cwd <cwd>` arguments.
+   *
+   * Defaults to `[]`; entries cannot contain null bytes.
+   */
   readonly args?: readonly string[]
+
+  /**
+   * OpenCode executable or application-owned launcher.
+   *
+   * Defaults to `"opencode"`. AML does not install OpenCode.
+   */
   readonly command?: string
-  readonly config?: Config
+
+  /**
+   * Native OpenCode configuration captured before external work begins.
+   *
+   * Defaults to `{}` and must contain only finite, acyclic JSON values. AML
+   * preserves native settings, then applies its generated Agent profile,
+   * effective model, Tool configuration, and permission denials.
+   */
+  readonly config?: OpenCodeConfig
+
+  /**
+   * Fallback launch directory when no active Sandbox supplies one.
+   *
+   * Omit to use the application working directory.
+   */
   readonly directory?: string
+
+  /**
+   * Additional environment variables for credentials and provider settings.
+   *
+   * Defaults to `{}`. AML writes invocation-private OpenCode state variables
+   * afterward; only an explicit `XDG_DATA_HOME` is intentionally preserved.
+   */
   readonly env?: Readonly<Record<string, string>>
+
+  /**
+   * Provider-level model fallback.
+   *
+   * Precedence is `<Agent model>`, this option, then `config.model`, followed by
+   * OpenCode's own default.
+   */
   readonly model?: string
 }
 
@@ -18,7 +57,7 @@ export interface OpenCodeAgentOptions {
 export interface CapturedOpenCodeAgentOptions {
   readonly args: readonly string[]
   readonly command: string
-  readonly config: Readonly<Config>
+  readonly config: Readonly<OpenCodeConfig>
   readonly directory?: string
   readonly env: Readonly<Record<string, string>>
   readonly model?: string
@@ -59,7 +98,7 @@ export function captureOpenCodeAgentOptions(options: OpenCodeAgentOptions): Read
     throw new TypeError("OpenCode config must be an object")
   }
 
-  const capturedConfig = captureJson(config, "OpenCode config") as Readonly<Config>
+  const capturedConfig = captureJson(config, "OpenCode config") as Readonly<OpenCodeConfig>
 
   return Object.freeze({
     args: Object.freeze([...args]),

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -13,7 +13,9 @@ import {
   type OpenCodeAgentOptions,
 } from "./opencode-agent-options.js"
 
+/** Agent provider returned by {@link opencodeAgent}. */
 export interface OpenCodeAgentProvider extends AgentProvider {
+  /** Stable provider identifier reported in Agent requests and traces. */
   readonly name: "opencode"
 }
 
@@ -143,6 +145,13 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
 
 /**
  * Creates an OpenCode Agent through its native ACP server.
+ *
+ * The selected host or Sandbox must contain the configured OpenCode command.
+ * Options are validated and captured before process acquisition. AML translates
+ * portable permissions into OpenCode Tool and permission denials, while the
+ * enclosing Sandbox remains the process-level enforcement boundary.
+ *
+ * @param options Native configuration, command, environment, model, and directory.
  */
 export function opencodeAgent(options: OpenCodeAgentOptions = {}): Readonly<OpenCodeAgentProvider> {
   const profile = new OpenCodeAcpProfile(captureOpenCodeAgentOptions(options))

--- a/providers/agents/opencode/src/opencode-config.ts
+++ b/providers/agents/opencode/src/opencode-config.ts
@@ -1,0 +1,854 @@
+/** OpenCode log levels ordered from most to least verbose. */
+type OpenCodeLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR"
+
+/** Listener settings used by OpenCode's `serve` and `web` commands. */
+interface OpenCodeServerConfig {
+  /** TCP port on which the OpenCode server listens. */
+  port?: number
+
+  /** Hostname or IP address to which the server binds. */
+  hostname?: string
+
+  /** Whether to advertise the server over multicast DNS. */
+  mdns?: boolean
+
+  /** Custom multicast-DNS domain advertised for the server. */
+  mdnsDomain?: string
+
+  /** Browser origins allowed to make cross-origin requests to the server. */
+  cors?: string[]
+}
+
+/** One named OpenCode command and the prompt it expands to. */
+interface OpenCodeCommandDefinition {
+  /** Prompt template rendered when the command is invoked. */
+  template: string
+
+  /** Human-readable command description shown by OpenCode. */
+  description?: string
+
+  /** Agent profile selected when the command runs. */
+  agent?: string
+
+  /** Provider/model identifier selected for the command. */
+  model?: string
+
+  /** Model variant selected for the command. */
+  variant?: string
+
+  /** Whether the command runs as a delegated subtask. */
+  subtask?: boolean
+}
+
+/** Named command definitions keyed by the command users invoke. */
+interface OpenCodeCommandConfig {
+  /** Defines one command under its OpenCode command name. */
+  [name: string]: OpenCodeCommandDefinition
+}
+
+/** Additional locations from which OpenCode discovers Agent Skills. */
+interface OpenCodeSkillsConfig {
+  /** Filesystem paths searched for skills. */
+  paths?: string[]
+
+  /** Remote URLs from which skills are loaded. */
+  urls?: string[]
+}
+
+/** Git-backed reference content available to OpenCode. */
+interface OpenCodeGitReferenceConfig {
+  /** Git repository URL or repository identifier. */
+  repository: string
+
+  /** Branch selected from the repository; omitted to use its default branch. */
+  branch?: string
+
+  /** Human-readable explanation of the reference. */
+  description?: string
+
+  /** Whether OpenCode hides the reference from normal discovery. */
+  hidden?: boolean
+}
+
+/** Filesystem-backed reference content available to OpenCode. */
+interface OpenCodeLocalReferenceConfig {
+  /** Local path containing the reference content. */
+  path: string
+
+  /** Human-readable explanation of the reference. */
+  description?: string
+
+  /** Whether OpenCode hides the reference from normal discovery. */
+  hidden?: boolean
+}
+
+/** A direct reference string, Git source, or local filesystem source. */
+type OpenCodeReferenceConfig = string | OpenCodeGitReferenceConfig | OpenCodeLocalReferenceConfig
+
+/** Named OpenCode references keyed by the name exposed to Agents. */
+interface OpenCodeReferencesConfig {
+  /** Defines one reference under its OpenCode-visible name. */
+  [name: string]: OpenCodeReferenceConfig
+}
+
+/** File-watcher behavior for the OpenCode project. */
+interface OpenCodeWatcherConfig {
+  /** Path patterns excluded from filesystem watching. */
+  ignore?: string[]
+}
+
+/** Provider-native settings passed to an OpenCode plugin. */
+interface OpenCodePluginOptions {
+  /** Supplies one plugin-defined JSON-compatible option. */
+  [name: string]: unknown
+}
+
+/** Plugin package name, optionally paired with its native options. */
+type OpenCodePluginConfig = string | [name: string, options: OpenCodePluginOptions]
+
+/** Decision OpenCode applies when a permission rule matches. */
+type OpenCodePermissionAction = "ask" | "allow" | "deny"
+
+/** Resource-pattern decisions for one OpenCode permission category. */
+interface OpenCodePermissionObjectConfig {
+  /** Applies a permission action to one resource pattern. */
+  [resource: string]: OpenCodePermissionAction
+}
+
+/** A category-wide permission action or resource-specific permission table. */
+type OpenCodePermissionRuleConfig = OpenCodePermissionAction | OpenCodePermissionObjectConfig
+
+/** Per-capability native permission policy understood by OpenCode. */
+interface OpenCodePermissionRulesConfig {
+  /** Permission applied when Agents read files. */
+  read?: OpenCodePermissionRuleConfig
+
+  /** Permission applied when Agents edit files. */
+  edit?: OpenCodePermissionRuleConfig
+
+  /** Permission applied to filesystem glob searches. */
+  glob?: OpenCodePermissionRuleConfig
+
+  /** Permission applied to text searches. */
+  grep?: OpenCodePermissionRuleConfig
+
+  /** Permission applied to directory listings. */
+  list?: OpenCodePermissionRuleConfig
+
+  /** Permission applied to shell commands. */
+  bash?: OpenCodePermissionRuleConfig
+
+  /** Permission applied when spawning native subagents. */
+  task?: OpenCodePermissionRuleConfig
+
+  /** Permission applied when accessing paths outside the project directory. */
+  external_directory?: OpenCodePermissionRuleConfig
+
+  /** Permission applied when an Agent updates its todo list. */
+  todowrite?: OpenCodePermissionAction
+
+  /** Permission applied when an Agent asks the user a question. */
+  question?: OpenCodePermissionAction
+
+  /** Permission applied to fetching a known web address. */
+  webfetch?: OpenCodePermissionAction
+
+  /** Permission applied to web searches. */
+  websearch?: OpenCodePermissionAction
+
+  /** Permission applied to language-server operations. */
+  lsp?: OpenCodePermissionRuleConfig
+
+  /** Permission applied when OpenCode detects a repeated tool-call loop. */
+  doom_loop?: OpenCodePermissionAction
+
+  /** Permission applied when loading a skill. */
+  skill?: OpenCodePermissionRuleConfig
+
+  /** Defines a native or plugin permission category not listed above. */
+  [permission: string]: OpenCodePermissionRuleConfig | OpenCodePermissionAction | undefined
+}
+
+/** Global permission action or per-capability native OpenCode policy. */
+type OpenCodePermissionConfig = OpenCodePermissionAction | OpenCodePermissionRulesConfig
+
+/** Native tool enablement keyed by OpenCode tool name or pattern. */
+interface OpenCodeToolConfig {
+  /** Enables or disables matching native tools. */
+  [tool: string]: boolean
+}
+
+/** Provider-native options passed to one OpenCode Agent profile. */
+interface OpenCodeAgentOptionsConfig {
+  /** Supplies one OpenCode or model-provider-specific Agent option. */
+  [name: string]: unknown
+}
+
+/** Configuration for one native OpenCode Agent profile. */
+interface OpenCodeAgentConfig {
+  /** Provider/model identifier used by the Agent. */
+  model?: string
+
+  /** Named variant selected for the model. */
+  variant?: string
+
+  /** Sampling temperature passed to models that support it. */
+  temperature?: number
+
+  /** Nucleus-sampling threshold passed to models that support it. */
+  top_p?: number
+
+  /** Additional system prompt supplied to the Agent. */
+  prompt?: string
+
+  /** Native tool enablement overrides for this Agent. */
+  tools?: OpenCodeToolConfig
+
+  /** Whether OpenCode excludes this Agent from use. */
+  disable?: boolean
+
+  /** Human-readable role description used for Agent discovery. */
+  description?: string
+
+  /** Whether the Agent is primary, delegated, or available in both roles. */
+  mode?: "subagent" | "primary" | "all"
+
+  /** Whether OpenCode hides the Agent from normal selection interfaces. */
+  hidden?: boolean
+
+  /** Provider-native request and model options for this Agent. */
+  options?: OpenCodeAgentOptionsConfig
+
+  /** Hex or theme color used to display the Agent. */
+  color?: string
+
+  /** Maximum number of execution steps allowed for this Agent. */
+  steps?: number
+
+  /** Legacy alias for the Agent execution-step limit. */
+  maxSteps?: number
+
+  /** Native permission policy applied to this Agent. */
+  permission?: OpenCodePermissionConfig
+
+  /** Preserves OpenCode or plugin Agent properties introduced by the bundled SDK. */
+  [name: string]: unknown
+}
+
+/** Legacy build, plan, and custom OpenCode mode definitions. */
+interface OpenCodeModeConfig {
+  /** Native build-mode Agent profile. */
+  build?: OpenCodeAgentConfig
+
+  /** Native plan-mode Agent profile. */
+  plan?: OpenCodeAgentConfig
+
+  /** Defines an additional mode under its native OpenCode name. */
+  [name: string]: OpenCodeAgentConfig | undefined
+}
+
+/** Named native Agent profiles recognized by OpenCode. */
+interface OpenCodeAgentProfilesConfig {
+  /** Native plan Agent profile. */
+  plan?: OpenCodeAgentConfig
+
+  /** Native build Agent profile. */
+  build?: OpenCodeAgentConfig
+
+  /** General-purpose delegated Agent profile. */
+  general?: OpenCodeAgentConfig
+
+  /** Repository-exploration Agent profile. */
+  explore?: OpenCodeAgentConfig
+
+  /** Agent profile used to generate session titles. */
+  title?: OpenCodeAgentConfig
+
+  /** Agent profile used to generate summaries. */
+  summary?: OpenCodeAgentConfig
+
+  /** Agent profile used during context compaction. */
+  compaction?: OpenCodeAgentConfig
+
+  /** Defines another Agent under its native OpenCode name. */
+  [name: string]: OpenCodeAgentConfig | undefined
+}
+
+/** Provider-specific connection and request options. */
+interface OpenCodeProviderOptionsConfig {
+  /** API credential passed to the provider. */
+  apiKey?: string
+
+  /** Base API URL used instead of the provider's default endpoint. */
+  baseURL?: string
+
+  /** Enterprise service URL used by providers that distinguish it. */
+  enterpriseUrl?: string
+
+  /** Whether the provider sets a stable cache key for supported requests. */
+  setCacheKey?: boolean
+
+  /** Full-request timeout in milliseconds, or `false` to disable it. */
+  timeout?: number | false
+
+  /** Response-header timeout in milliseconds, or `false` to disable it. */
+  headerTimeout?: number | false
+
+  /** Maximum delay in milliseconds between streamed response chunks. */
+  chunkTimeout?: number
+
+  /** Supplies another provider-native option. */
+  [name: string]: unknown
+}
+
+/** Field used by providers that return reasoning in an interleaved response. */
+interface OpenCodeModelInterleavingConfig {
+  /** Response field containing the interleaved reasoning payload. */
+  field: "reasoning" | "reasoning_content" | "reasoning_details"
+}
+
+/** Provider-reported pricing for one model usage tier. */
+interface OpenCodeModelTierCostConfig {
+  /** Price assigned to input tokens. */
+  input: number
+
+  /** Price assigned to output tokens. */
+  output: number
+
+  /** Optional price assigned to cached input reads. */
+  cache_read?: number
+
+  /** Optional price assigned to cached input writes. */
+  cache_write?: number
+}
+
+/** Provider-reported pricing used by OpenCode for a model. */
+interface OpenCodeModelCostConfig extends OpenCodeModelTierCostConfig {
+  /** Alternate pricing applied when context exceeds 200,000 tokens. */
+  context_over_200k?: OpenCodeModelTierCostConfig
+}
+
+/** Token limits advertised for one configured model. */
+interface OpenCodeModelLimitConfig {
+  /** Maximum context-window size in tokens. */
+  context: number
+
+  /** Optional maximum input size in tokens. */
+  input?: number
+
+  /** Maximum output size in tokens. */
+  output: number
+}
+
+/** Content kinds accepted or produced by a configured model. */
+type OpenCodeModelModality = "text" | "audio" | "image" | "video" | "pdf"
+
+/** Input and output modalities advertised for one model. */
+interface OpenCodeModelModalitiesConfig {
+  /** Content kinds the model accepts as input. */
+  input?: OpenCodeModelModality[]
+
+  /** Content kinds the model may emit as output. */
+  output?: OpenCodeModelModality[]
+}
+
+/** Model-specific provider adapter override. */
+interface OpenCodeModelProviderConfig {
+  /** npm package implementing the model adapter. */
+  npm?: string
+
+  /** API identifier used by the adapter. */
+  api?: string
+}
+
+/** Provider-native options passed only to one configured model. */
+interface OpenCodeModelOptionsConfig {
+  /** Supplies one model-provider-specific option. */
+  [name: string]: unknown
+}
+
+/** HTTP headers added to requests for one configured model. */
+interface OpenCodeModelHeadersConfig {
+  /** Supplies one request header value. */
+  [name: string]: string
+}
+
+/** Provider-native options for one named model variant. */
+interface OpenCodeModelVariantConfig {
+  /** Whether the variant is unavailable for selection. */
+  disabled?: boolean
+
+  /** Supplies another model-variant option. */
+  [name: string]: unknown
+}
+
+/** Named model variants exposed by OpenCode. */
+interface OpenCodeModelVariantsConfig {
+  /** Defines one variant under its selectable name. */
+  [name: string]: OpenCodeModelVariantConfig
+}
+
+/** One model added to or overridden within an OpenCode provider. */
+interface OpenCodeProviderModelConfig {
+  /** Provider-native model identifier. */
+  id?: string
+
+  /** Human-readable model name displayed by OpenCode. */
+  name?: string
+
+  /** Model family used for grouping and compatibility behavior. */
+  family?: string
+
+  /** Model release date understood by OpenCode. */
+  release_date?: string
+
+  /** Whether the model accepts file or image attachments. */
+  attachment?: boolean
+
+  /** Whether the model supports reasoning output. */
+  reasoning?: boolean
+
+  /** Whether callers may configure sampling temperature. */
+  temperature?: boolean
+
+  /** Whether the model supports tool calls. */
+  tool_call?: boolean
+
+  /** Whether and where reasoning is interleaved with normal output. */
+  interleaved?: true | OpenCodeModelInterleavingConfig
+
+  /** Provider-reported usage pricing. */
+  cost?: OpenCodeModelCostConfig
+
+  /** Context, input, and output token limits. */
+  limit?: OpenCodeModelLimitConfig
+
+  /** Content kinds accepted and emitted by the model. */
+  modalities?: OpenCodeModelModalitiesConfig
+
+  /** Whether OpenCode treats the model definition as experimental. */
+  experimental?: boolean
+
+  /** Model lifecycle status displayed by OpenCode. */
+  status?: "alpha" | "beta" | "deprecated" | "active"
+
+  /** Adapter package or API override for this model. */
+  provider?: OpenCodeModelProviderConfig
+
+  /** Provider-native options passed to this model. */
+  options?: OpenCodeModelOptionsConfig
+
+  /** HTTP headers added to this model's requests. */
+  headers?: OpenCodeModelHeadersConfig
+
+  /** Named provider-native variants of this model. */
+  variants?: OpenCodeModelVariantsConfig
+}
+
+/** Named model definitions owned by one provider. */
+interface OpenCodeProviderModelsConfig {
+  /** Defines one model under its OpenCode-visible identifier. */
+  [model: string]: OpenCodeProviderModelConfig
+}
+
+/** Native configuration for one OpenCode model provider. */
+interface OpenCodeProviderConfig {
+  /** API identifier used by the provider adapter. */
+  api?: string
+
+  /** Human-readable provider name. */
+  name?: string
+
+  /** Environment-variable names from which credentials may be discovered. */
+  env?: string[]
+
+  /** Native provider identifier. */
+  id?: string
+
+  /** npm package implementing the provider adapter. */
+  npm?: string
+
+  /** Model identifiers explicitly allowed from this provider. */
+  whitelist?: string[]
+
+  /** Model identifiers excluded from this provider. */
+  blacklist?: string[]
+
+  /** Provider connection, credential, and request options. */
+  options?: OpenCodeProviderOptionsConfig
+
+  /** Models added to or overridden for this provider. */
+  models?: OpenCodeProviderModelsConfig
+}
+
+/** Named OpenCode providers keyed by provider identifier. */
+interface OpenCodeProvidersConfig {
+  /** Configures one provider under its OpenCode identifier. */
+  [provider: string]: OpenCodeProviderConfig
+}
+
+/** Environment variables supplied to a local MCP server process. */
+interface OpenCodeMcpEnvironmentConfig {
+  /** Supplies one environment variable. */
+  [name: string]: string
+}
+
+/** Native local-process MCP server configuration. */
+interface OpenCodeLocalMcpConfig {
+  /** Selects local process transport. */
+  type: "local"
+
+  /** Executable followed by arguments used to launch the MCP server. */
+  command: string[]
+
+  /** Working directory from which the MCP process starts. */
+  cwd?: string
+
+  /** Environment variables supplied to the MCP process. */
+  environment?: OpenCodeMcpEnvironmentConfig
+
+  /** Whether OpenCode starts and exposes this server. */
+  enabled?: boolean
+
+  /** MCP connection timeout in milliseconds. */
+  timeout?: number
+}
+
+/** OAuth client settings for a remote MCP server. */
+interface OpenCodeMcpOAuthConfig {
+  /** OAuth client identifier. */
+  clientId?: string
+
+  /** OAuth client secret. */
+  clientSecret?: string
+
+  /** Space-delimited OAuth scopes requested from the server. */
+  scope?: string
+
+  /** Local callback port used during OAuth authorization. */
+  callbackPort?: number
+
+  /** Explicit OAuth redirect URI. */
+  redirectUri?: string
+}
+
+/** HTTP headers supplied to a remote MCP server. */
+interface OpenCodeMcpHeadersConfig {
+  /** Supplies one remote MCP request header. */
+  [name: string]: string
+}
+
+/** Native remote HTTP MCP server configuration. */
+interface OpenCodeRemoteMcpConfig {
+  /** Selects remote transport. */
+  type: "remote"
+
+  /** URL of the remote MCP endpoint. */
+  url: string
+
+  /** Whether OpenCode connects to and exposes this server. */
+  enabled?: boolean
+
+  /** HTTP headers supplied to the remote MCP endpoint. */
+  headers?: OpenCodeMcpHeadersConfig
+
+  /** OAuth settings, or `false` to disable OAuth auto-detection. */
+  oauth?: OpenCodeMcpOAuthConfig | false
+
+  /** MCP request timeout in milliseconds. */
+  timeout?: number
+}
+
+/** Minimal override that only toggles an otherwise discovered MCP server. */
+interface OpenCodeEnabledMcpConfig {
+  /** Whether OpenCode exposes the discovered server. */
+  enabled: boolean
+}
+
+/** Named native MCP servers keyed by the name exposed to OpenCode Agents. */
+interface OpenCodeMcpConfig {
+  /** Defines or toggles one native MCP server. */
+  [name: string]: OpenCodeLocalMcpConfig | OpenCodeRemoteMcpConfig | OpenCodeEnabledMcpConfig
+}
+
+/** Environment variables supplied to one formatter process. */
+interface OpenCodeFormatterEnvironmentConfig {
+  /** Supplies one formatter environment variable. */
+  [name: string]: string
+}
+
+/** Override for one built-in or custom formatter. */
+interface OpenCodeFormatterConfig {
+  /** Whether OpenCode disables this formatter. */
+  disabled?: boolean
+
+  /** Executable followed by arguments used to format a file. */
+  command?: string[]
+
+  /** Environment variables supplied to the formatter process. */
+  environment?: OpenCodeFormatterEnvironmentConfig
+
+  /** File extensions handled by the formatter. */
+  extensions?: string[]
+}
+
+/** Formatter overrides keyed by built-in or custom formatter name. */
+interface OpenCodeFormattersConfig {
+  /** Configures one formatter. */
+  [name: string]: OpenCodeFormatterConfig
+}
+
+/** Configuration that explicitly disables one language server. */
+interface OpenCodeDisabledLspConfig {
+  /** Required disable marker for this language-server entry. */
+  disabled: true
+}
+
+/** Environment variables supplied to one language-server process. */
+interface OpenCodeLspEnvironmentConfig {
+  /** Supplies one language-server environment variable. */
+  [name: string]: string
+}
+
+/** JSON-compatible initialization options passed to a language server. */
+interface OpenCodeLspInitializationConfig {
+  /** Supplies one server-specific initialization option. */
+  [name: string]: unknown
+}
+
+/** Launch configuration for a built-in or custom language server. */
+interface OpenCodeLspLaunchConfig {
+  /** Executable followed by arguments used to launch the language server. */
+  command: string[]
+
+  /** File extensions handled by the language server. */
+  extensions?: string[]
+
+  /** Whether OpenCode disables this language server. */
+  disabled?: boolean
+
+  /** Environment variables supplied to the language-server process. */
+  env?: OpenCodeLspEnvironmentConfig
+
+  /** Server-specific initialization options sent during LSP startup. */
+  initialization?: OpenCodeLspInitializationConfig
+}
+
+/** Language-server overrides keyed by built-in or custom server name. */
+interface OpenCodeLanguageServersConfig {
+  /** Disables or configures one language server. */
+  [name: string]: OpenCodeDisabledLspConfig | OpenCodeLspLaunchConfig
+}
+
+/** Image normalization and size limits for OpenCode attachments. */
+interface OpenCodeImageAttachmentConfig {
+  /** Whether OpenCode automatically resizes oversized images. */
+  auto_resize?: boolean
+
+  /** Maximum image width in pixels. */
+  max_width?: number
+
+  /** Maximum image height in pixels. */
+  max_height?: number
+
+  /** Maximum encoded image payload size in bytes. */
+  max_base64_bytes?: number
+}
+
+/** Attachment handling behavior used by OpenCode. */
+interface OpenCodeAttachmentConfig {
+  /** Image resizing and payload limits. */
+  image?: OpenCodeImageAttachmentConfig
+}
+
+/** Enterprise service connection used by OpenCode. */
+interface OpenCodeEnterpriseConfig {
+  /** Base URL of the enterprise OpenCode service. */
+  url?: string
+}
+
+/** Retention limits applied to native tool output. */
+interface OpenCodeToolOutputConfig {
+  /** Maximum number of output lines retained. */
+  max_lines?: number
+
+  /** Maximum number of output bytes retained. */
+  max_bytes?: number
+}
+
+/** Automatic context compaction and pruning behavior. */
+interface OpenCodeCompactionConfig {
+  /** Whether OpenCode compacts automatically near the context limit. */
+  auto?: boolean
+
+  /** Whether OpenCode removes old tool output during compaction. */
+  prune?: boolean
+
+  /** Number of recent conversation turns retained during compaction. */
+  tail_turns?: number
+
+  /** Number of recent tokens retained during compaction. */
+  preserve_recent_tokens?: number
+
+  /** Token capacity reserved for compaction output and subsequent work. */
+  reserved?: number
+}
+
+/** Allow-or-deny rule for one experimental OpenCode resource policy. */
+interface OpenCodeExperimentalPolicyConfig {
+  /** Policy action; the bundled SDK currently supports provider use. */
+  action: "provider.use"
+
+  /** Whether matching access is permitted. */
+  effect: "allow" | "deny"
+
+  /** Resource selector to which the policy applies. */
+  resource: string
+}
+
+/** Unstable settings whose behavior may change between OpenCode versions. */
+interface OpenCodeExperimentalConfig {
+  /** Whether OpenCode suppresses summaries for large pasted content. */
+  disable_paste_summary?: boolean
+
+  /** Whether OpenCode enables its experimental batched-tool behavior. */
+  batch_tool?: boolean
+
+  /** Whether OpenCode emits OpenTelemetry data. */
+  openTelemetry?: boolean
+
+  /** Native tools promoted for primary-Agent use. */
+  primary_tools?: string[]
+
+  /** Whether an Agent loop continues after a denied permission request. */
+  continue_loop_on_deny?: boolean
+
+  /** Experimental default MCP timeout in milliseconds. */
+  mcp_timeout?: number
+
+  /** Experimental resource policies evaluated by OpenCode. */
+  policies?: OpenCodeExperimentalPolicyConfig[]
+}
+
+/**
+ * Native OpenCode configuration accepted by {@link opencodeAgent}.
+ *
+ * Every top-level property is optional. Optional nested properties remain
+ * absent unless authored, leaving the bundled OpenCode version to apply its
+ * native behavior. AML requires a finite, acyclic JSON graph, captures it before
+ * process acquisition, then overlays the effective AML model, Agent profile,
+ * tools, and permission denials.
+ */
+export interface OpenCodeConfig {
+  /** JSON Schema URL used by editors to validate a serialized config file. */
+  $schema?: string
+
+  /** Shell command selected by OpenCode for native shell execution. */
+  shell?: string
+
+  /** Minimum OpenCode log level; omitted to use OpenCode's default. */
+  logLevel?: OpenCodeLogLevel
+
+  /** Server and listener settings for OpenCode's serve and web commands. */
+  server?: OpenCodeServerConfig
+
+  /** Named custom commands and their prompt templates. */
+  command?: OpenCodeCommandConfig
+
+  /** Additional filesystem paths or URLs from which OpenCode discovers skills. */
+  skills?: OpenCodeSkillsConfig
+
+  /** Named local, Git, or string reference definitions available to OpenCode. */
+  references?: OpenCodeReferencesConfig
+
+  /** Alternate singular reference table supported by OpenCode. */
+  reference?: OpenCodeReferencesConfig
+
+  /** File-watcher settings, including ignored path patterns. */
+  watcher?: OpenCodeWatcherConfig
+
+  /** Whether OpenCode records filesystem snapshots for supported workflows. */
+  snapshot?: boolean
+
+  /** OpenCode plugins, optionally paired with provider-native plugin options. */
+  plugin?: OpenCodePluginConfig[]
+
+  /** Session sharing policy: manual, automatic, or disabled. */
+  share?: "manual" | "auto" | "disabled"
+
+  /** Legacy automatic-sharing switch understood by OpenCode. */
+  autoshare?: boolean
+
+  /** Automatic update policy or notification-only mode. */
+  autoupdate?: boolean | "notify"
+
+  /** Provider identifiers OpenCode must not load. */
+  disabled_providers?: string[]
+
+  /** Provider allowlist OpenCode may load. */
+  enabled_providers?: string[]
+
+  /** Native default model; lower precedence than `OpenCodeAgentOptions.model`. */
+  model?: string
+
+  /** Smaller model used by OpenCode for lightweight internal work. */
+  small_model?: string
+
+  /** Native default Agent name; AML replaces this with its generated `aml` profile. */
+  default_agent?: string
+
+  /** Maximum nesting depth for OpenCode-native subagents. */
+  subagent_depth?: number
+
+  /** Display name OpenCode associates with the current user. */
+  username?: string
+
+  /** Legacy build, plan, and custom mode definitions. */
+  mode?: OpenCodeModeConfig
+
+  /** Native Agent profile definitions; AML preserves entries other than `aml`. */
+  agent?: OpenCodeAgentProfilesConfig
+
+  /** Provider credentials, models, endpoints, and provider-native options. */
+  provider?: OpenCodeProvidersConfig
+
+  /** Native local and remote MCP server definitions. */
+  mcp?: OpenCodeMcpConfig
+
+  /** `false` disables formatters, `true` enables defaults, and a table applies overrides. */
+  formatter?: boolean | OpenCodeFormattersConfig
+
+  /** `false` disables LSP, `true` enables defaults, and a table applies server overrides. */
+  lsp?: boolean | OpenCodeLanguageServersConfig
+
+  /** Additional instruction files or patterns loaded by OpenCode. */
+  instructions?: string[]
+
+  /**
+   * Native interface layout setting.
+   *
+   * @deprecated The bundled OpenCode version always uses stretch layout.
+   */
+  layout?: "auto" | "stretch"
+
+  /** Base native permission policy; AML's effective denials take precedence. */
+  permission?: OpenCodePermissionConfig
+
+  /** Base native tool enablement; AML's effective tool denials take precedence. */
+  tools?: OpenCodeToolConfig
+
+  /** Attachment and image-size handling limits. */
+  attachment?: OpenCodeAttachmentConfig
+
+  /** Enterprise OpenCode service configuration. */
+  enterprise?: OpenCodeEnterpriseConfig
+
+  /** Maximum lines and bytes retained from native tool output. */
+  tool_output?: OpenCodeToolOutputConfig
+
+  /** Automatic context compaction and retention settings. */
+  compaction?: OpenCodeCompactionConfig
+
+  /** Unstable OpenCode feature flags and experimental policies. */
+  experimental?: OpenCodeExperimentalConfig
+}

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -1,12 +1,17 @@
 import { agent, methods, ndJsonStream, type SessionConfigOption } from "@agentclientprotocol/sdk"
+import type { Config as OpenCodeSdkConfig } from "@opencode-ai/sdk/v2"
 import { Agent, AmlRuntime, defineTool, evaluate, FollowUp, Sandbox, Tool, type SandboxProcess } from "@aml-jsx/sdk"
 import { DeterministicSandboxProvider } from "@aml-jsx/sdk/testing"
-import { describe, expect, it } from "vitest"
+import { describe, expect, expectTypeOf, it } from "vitest"
 import { z } from "zod"
 
-import { opencodeAgent } from "../src/index.js"
+import { opencodeAgent, type OpenCodeConfig } from "../src/index.js"
 
 describe("opencodeAgent()", () => {
+  it("keeps its documented configuration in exact parity with the bundled OpenCode SDK", () => {
+    expectTypeOf<OpenCodeConfig>().toEqualTypeOf<OpenCodeSdkConfig>()
+  })
+
   it("launches the native ACP Agent through the Sandbox process boundary", async () => {
     const spawned: Array<{
       readonly args: readonly string[]

--- a/providers/agents/pi/src/pi-agent.ts
+++ b/providers/agents/pi/src/pi-agent.ts
@@ -10,23 +10,70 @@ import {
  * Configures the maintained pi-acp adapter and underlying Pi command.
  */
 export interface PiAgentOptions {
+  /**
+   * Arguments appended to the `pi-acp` command exactly as supplied.
+   *
+   * Defaults to `[]`; entries cannot contain null bytes.
+   */
   readonly args?: readonly string[]
+
+  /**
+   * Outer ACP adapter executable or application-owned launcher.
+   *
+   * Defaults to `"pi-acp"`. AML does not install the adapter.
+   */
   readonly command?: string
+
+  /**
+   * Additional environment variables for credentials and native Pi settings.
+   *
+   * Defaults to `{}`. AML-owned private HOME, state, command, and version-check
+   * variables are written afterward.
+   */
   readonly env?: Readonly<Record<string, string>>
   /**
    * Path to the environment-installed pi-mcp-adapter entrypoint.
    *
    * When omitted, the launch wrapper resolves the installed package beside its
    * `pi-mcp-adapter` executable. AML never installs runtime software implicitly.
+   * The value must be a non-empty, already-trimmed path without null bytes.
    */
   readonly mcpAdapterPath?: string
+
+  /**
+   * Provider-level model fallback.
+   *
+   * Omit to let Pi choose its configured default. An `<Agent model>` prop takes
+   * precedence and is sent through ACP session configuration.
+   */
   readonly model?: string
+
+  /**
+   * Native Pi executable used directly or by AML's generated permission wrapper.
+   *
+   * Defaults to `"pi"`; this is distinct from the outer ACP `command`.
+   */
   readonly piCommand?: string
+
+  /**
+   * Provider-native Pi thought-level configuration value.
+   *
+   * Omitted by default. AML validates and forwards the normalized string but
+   * does not maintain an adapter-version-specific allowlist.
+   */
   readonly thinkingLevel?: string
+
+  /**
+   * Fallback working directory when no active Sandbox supplies one.
+   *
+   * Omit to use the application working directory.
+   */
   readonly workingDirectory?: string
 }
 
+/** Agent provider returned by {@link piAgent}. */
 export interface PiAgentProvider extends AgentProvider {
+  /** Stable provider identifier reported in Agent requests and traces. */
   readonly name: "pi"
 }
 
@@ -149,6 +196,13 @@ class PiAcpProfile implements AcpAgentProfile<"pi"> {
 
 /**
  * Creates a Pi coding Agent through the maintained pi-acp adapter.
+ *
+ * The selected host or Sandbox must contain `pi-acp`, Pi, and the MCP adapter
+ * when capabilities require it. AML generates a tool-restricting wrapper when
+ * permissions are narrowed or MCP is present; an enclosing Sandbox remains the
+ * process-level enforcement boundary.
+ *
+ * @param options Adapter command, native Pi command, environment, and defaults.
  */
 export function piAgent(options: PiAgentOptions = {}): Readonly<PiAgentProvider> {
   const profile = new PiAcpProfile(captureOptions(options))

--- a/providers/sandboxes/daytona/src/daytona-sandbox.ts
+++ b/providers/sandboxes/daytona/src/daytona-sandbox.ts
@@ -31,17 +31,62 @@ const DEFAULT_IMAGE = "wearesingular/aml-agent-sandbox:latest"
 const GUEST_ROOT = "workspace"
 const execFileAsync = promisify(execFile)
 
+/** Daytona SDK controls applied while creating the remote Sandbox. */
 export interface DaytonaSandboxCreateOptions {
+  /**
+   * Receives provider-native image snapshot creation log chunks.
+   *
+   * Omitted by default and used only for image-based creation; snapshot-based
+   * creation does not expose this callback in the Daytona SDK.
+   */
   readonly onSnapshotCreateLogs?: (chunk: string) => void
+
+  /**
+   * Daytona creation timeout in seconds.
+   *
+   * Omit for the Daytona SDK default of 60 seconds. The provider-native value
+   * `0` disables that timeout.
+   */
   readonly timeout?: number
 }
 
+/** Options shared by image- and snapshot-backed Daytona Sandboxes. */
 interface DaytonaSandboxSharedOptions {
+  /**
+   * Preconstructed Daytona client to use for every acquisition.
+   *
+   * Omitted by default and mutually exclusive with `config`.
+   */
   readonly client?: Daytona
+
+  /**
+   * Daytona SDK configuration used to construct a client lazily.
+   *
+   * Omitted by default and mutually exclusive with `client`.
+   */
   readonly config?: DaytonaConfig
+
+  /** Provider-native creation timeout and image snapshot log callback. */
   readonly createOptions?: DaytonaSandboxCreateOptions
+
+  /**
+   * Maximum combined command output and Workspace transfer budget.
+   *
+   * Defaults to `4 * 1024 * 1024` bytes and must be a positive safe integer.
+   */
   readonly maxOutputBytes?: number
+
+  /**
+   * Shell source run through `sh -lc` after Workspace hydration and before the
+   * lease is returned. Omitted by default; a non-zero exit rejects acquisition.
+   */
   readonly setup?: string
+
+  /**
+   * Fallback local Workspace directory when no active `<Workspace>` exists.
+   *
+   * Omitted by default. An active Workspace materialization takes precedence.
+   */
   readonly workspace?: string
 }
 
@@ -54,13 +99,31 @@ interface DaytonaSandboxSharedOptions {
 export type DaytonaSandboxOptions = DaytonaSandboxSharedOptions &
   (
     | {
+        /**
+         * Additional Daytona image-creation fields.
+         *
+         * `image` must remain at the factory root and cannot appear here.
+         */
         readonly create?: Omit<CreateSandboxFromImageParams, "image">
+
+        /** Image or declarative Daytona image used to create the environment. */
         readonly image: CreateSandboxFromImageParams["image"]
+
+        /** Snapshot creation is unavailable when an explicit image is selected. */
         readonly snapshot?: never
       }
     | {
+        /**
+         * Additional Daytona snapshot-creation fields.
+         *
+         * `snapshot` must remain at the factory root and cannot appear here.
+         */
         readonly create?: Omit<CreateSandboxFromSnapshotParams, "snapshot">
+
+        /** Image selection is unavailable on the snapshot branch. */
         readonly image?: never
+
+        /** Existing Daytona snapshot used for the environment. */
         readonly snapshot?: CreateSandboxFromSnapshotParams["snapshot"]
       }
   )
@@ -72,8 +135,12 @@ interface ParsedDaytonaSandboxOptions extends DaytonaSandboxSharedOptions {
   readonly snapshot?: CreateSandboxFromSnapshotParams["snapshot"]
 }
 
+/** Provider-specific handle exposed through a Daytona Sandbox lease. */
 export interface DaytonaSandboxHandle {
+  /** Stable provider-handle discriminant. */
   readonly kind: "daytona"
+
+  /** Live Daytona SDK Sandbox object for provider-native inspection or APIs. */
   readonly sandbox: DaytonaSdkSandbox
 }
 
@@ -87,6 +154,13 @@ interface DaytonaSandboxResource {
 /**
  * Creates disposable Daytona environments and transfers one Workspace into
  * `workspace` under Daytona's default working directory for each acquisition.
+ *
+ * Omitting both `image` and `snapshot` selects
+ * `wearesingular/aml-agent-sandbox:latest`. Writable release reconciles the
+ * remote Workspace back to its local materialization before destroying the
+ * environment; read-only release skips reconciliation.
+ *
+ * @param options Environment identity, Daytona client configuration, and lifecycle controls.
  */
 export function daytonaSandbox(options: DaytonaSandboxOptions = {}): Readonly<SandboxProvider<DaytonaSandboxHandle>> {
   return defineSandboxProvider(new DaytonaSandboxProvider(parseOptions(options)))

--- a/providers/sandboxes/docker/src/docker-sandbox.ts
+++ b/providers/sandboxes/docker/src/docker-sandbox.ts
@@ -25,10 +25,45 @@ const KEEPALIVE_COMMAND = "trap 'exit 0' TERM INT; while :; do sleep 3600 & wait
  * Image-first configuration for the local Docker CLI adapter.
  */
 export interface DockerSandboxOptions {
+  /**
+   * Image reference passed to `docker run`.
+   *
+   * Defaults to `"wearesingular/aml-agent-sandbox:latest"`. Pin a version or
+   * digest when reproducibility matters. The image must already contain every
+   * command and Agent dependency used by the workflow.
+   */
   readonly image?: string
+
+  /**
+   * Maximum combined output retained from a Docker CLI or Sandbox command.
+   *
+   * Defaults to `4 * 1024 * 1024` bytes and must be a positive safe integer.
+   */
   readonly maxOutputBytes?: number
+
+  /**
+   * Shell source run once through `sh -lc` after the container starts and the
+   * Workspace is mounted, before the lease is returned.
+   *
+   * Omitted by default. A non-zero exit rejects acquisition and removes the
+   * disposable container.
+   */
   readonly setup?: string
+
+  /**
+   * Docker user or `UID:GID` passed through `docker run --user`.
+   *
+   * Omit to use the image default. The value must be a non-empty,
+   * already-trimmed string without null bytes.
+   */
   readonly user?: string
+
+  /**
+   * Fallback host Workspace directory used when no active `<Workspace>` exists.
+   *
+   * Omitted by default and resolved when the factory is called. An active
+   * Workspace materialization takes precedence and is mounted at `/workspace`.
+   */
   readonly workspace?: string
 }
 
@@ -40,8 +75,12 @@ interface ParsedDockerSandboxOptions {
   readonly workspace?: string
 }
 
+/** Provider-specific identity exposed through a Docker Sandbox lease. */
 export interface DockerSandboxHandle {
+  /** Opaque Docker container id returned by `docker run`. */
   readonly containerId: string
+
+  /** Stable provider-handle discriminant. */
   readonly kind: "docker"
 }
 
@@ -63,6 +102,11 @@ interface CommandRunner {
  * Starts a named image through the local Docker CLI.
  *
  * AML does not build the image or install its Agent dependencies.
+ * Each acquisition creates a disposable `--rm` container, bind-mounts the
+ * effective Workspace at `/workspace`, and removes the container on release.
+ * Read-only access is enforced on that mount, not on the container filesystem.
+ *
+ * @param options Image, mount source, setup command, user, and output budget.
  */
 export function dockerSandbox(options: DockerSandboxOptions = {}): Readonly<SandboxProvider<DockerSandboxHandle>> {
   return createDockerSandboxProvider(options, new NodeCommandRunner())

--- a/providers/sandboxes/local/src/local-sandbox.ts
+++ b/providers/sandboxes/local/src/local-sandbox.ts
@@ -21,8 +21,29 @@ const DEFAULT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024
  * Trusted host-process configuration for `localSandbox()`.
  */
 export interface LocalSandboxOptions {
+  /**
+   * Maximum combined `stdout` and `stderr` collected from one command.
+   *
+   * Defaults to `4 * 1024 * 1024` bytes and must be a positive safe integer.
+   * Exceeding the budget kills the process and rejects the command.
+   */
   readonly maxOutputBytes?: number
+
+  /**
+   * Shell source run once per acquisition through `sh -lc` after path
+   * validation and before the lease is returned.
+   *
+   * Omitted by default. Because Local cannot execute safely under read-only
+   * access, configuring setup also requires an effective read-write Sandbox.
+   */
   readonly setup?: string
+
+  /**
+   * Fallback host Workspace directory used when no active `<Workspace>` exists.
+   *
+   * Omitted by default. Relative paths are resolved when the factory is called;
+   * an active Workspace materialization always takes precedence.
+   */
   readonly workspace?: string
 }
 
@@ -32,8 +53,12 @@ interface ParsedLocalSandboxOptions {
   readonly workspace?: string
 }
 
+/** Provider handle exposed through a Local Sandbox lease. */
 interface LocalSandboxHandle {
+  /** Resolved host directory represented by the Sandbox root. */
   readonly directory: string
+
+  /** Stable provider-handle discriminant. */
   readonly kind: "local"
 }
 
@@ -48,6 +73,10 @@ interface LocalSandboxResource {
  *
  * This provider is a composition and development proof, not an isolation
  * boundary. Use Docker or a remote provider for untrusted commands.
+ * Host commands require `access="read-write"`; Local rejects execution under
+ * read-only access because it cannot enforce that policy on an ordinary process.
+ *
+ * @param options Host Workspace, setup command, and command-output budget.
  */
 export function localSandbox(options: LocalSandboxOptions = {}): Readonly<SandboxProvider<LocalSandboxHandle>> {
   return defineSandboxProvider(new LocalSandboxProvider(parseOptions(options)))

--- a/providers/sandboxes/modal/src/modal-sandbox.ts
+++ b/providers/sandboxes/modal/src/modal-sandbox.ts
@@ -34,13 +34,60 @@ const execFileAsync = promisify(execFile)
  * Provider-native Modal configuration plus AML lifecycle conveniences.
  */
 export interface ModalSandboxOptions {
+  /**
+   * Modal app name opened with `createIfMissing: true`.
+   *
+   * Defaults to `"aml-jsx"`.
+   */
   readonly appName?: string
+
+  /**
+   * Preconstructed Modal client used for every acquisition.
+   *
+   * Omitted by default and mutually exclusive with `config`.
+   */
   readonly client?: ModalClient
+
+  /**
+   * Modal client configuration used to construct a client lazily.
+   *
+   * Omitted by default and mutually exclusive with `client`.
+   */
   readonly config?: ModalClientParams
+
+  /**
+   * Provider-native parameters forwarded to `client.sandboxes.create()`.
+   *
+   * Omitted by default. App and registry image identity remain root AML options.
+   */
   readonly create?: SandboxCreateParams
+
+  /**
+   * Registry image reference passed to `images.fromRegistry()`.
+   *
+   * Defaults to `"wearesingular/aml-agent-sandbox:latest"`. Pin an immutable
+   * version or digest when reproducibility matters.
+   */
   readonly image?: string
+
+  /**
+   * Maximum combined command output and Workspace transfer budget.
+   *
+   * Defaults to `4 * 1024 * 1024` bytes and must be a positive safe integer.
+   */
   readonly maxOutputBytes?: number
+
+  /**
+   * Shell source run through `sh -lc` after Workspace hydration and before the
+   * lease is returned. Omitted by default; a non-zero exit rejects acquisition.
+   */
   readonly setup?: string
+
+  /**
+   * Fallback local Workspace directory when no active `<Workspace>` exists.
+   *
+   * Omitted by default. An active Workspace materialization takes precedence.
+   */
   readonly workspace?: string
 }
 
@@ -50,8 +97,12 @@ interface ParsedModalSandboxOptions extends ModalSandboxOptions {
   readonly maxOutputBytes: number
 }
 
+/** Provider-specific handle exposed through a Modal Sandbox lease. */
 export interface ModalSandboxHandle {
+  /** Stable provider-handle discriminant. */
   readonly kind: "modal"
+
+  /** Live Modal SDK Sandbox object for provider-native inspection or APIs. */
   readonly sandbox: ModalSdkSandbox
 }
 
@@ -64,6 +115,12 @@ interface ModalSandboxResource {
 /**
  * Creates disposable Modal environments and transfers one Workspace into
  * `/workspace` for each acquisition.
+ *
+ * Writable release reconciles the full remote Workspace archive back to its
+ * local materialization before terminating the Sandbox; read-only release skips
+ * reconciliation. The local host must provide `tar` for transfer operations.
+ *
+ * @param options Modal client, app, image, creation, setup, and transfer controls.
  */
 export function modalSandbox(options: ModalSandboxOptions = {}): Readonly<SandboxProvider<ModalSandboxHandle>> {
   return defineSandboxProvider(new ModalSandboxProvider(parseOptions(options)))

--- a/providers/workspaces/local/src/filesystem-workspace.ts
+++ b/providers/workspaces/local/src/filesystem-workspace.ts
@@ -12,6 +12,7 @@ import {
   type PersistentWorkspaceHandle,
   type WorkspacePersistenceFormat,
   type WorkspaceProvider,
+  type WorkspaceStorageAcquireRequest,
   type WorkspaceStorageAdapter,
   type WorkspaceStorageBody,
   type WorkspaceStorageLease,
@@ -23,27 +24,81 @@ import lockfile from "proper-lockfile"
 const LOCK_STALE_MS = 20 * 60 * 1_000
 const LOCK_UPDATE_MS = 5 * 60 * 1_000
 
+/** Durable local storage root for {@link FilesystemWorkspaceStorage}. */
 export interface FilesystemWorkspaceStorageOptions {
+  /**
+   * Host directory under which revision objects and indexes are stored.
+   *
+   * The path is resolved during construction. It need not exist yet; storage
+   * namespaces are created lazily during acquisition.
+   */
   readonly directory: string
 }
 
+/**
+ * Configuration for a staged, revisioned Workspace persisted on this host.
+ */
 export interface FilesystemWorkspaceOptions extends FilesystemWorkspaceStorageOptions {
+  /**
+   * Representation used for new revisions.
+   *
+   * Defaults to `"archive"`; `"folder"` stores selected files as individual
+   * objects. Existing revisions retain and restore their recorded format.
+   */
   readonly format?: WorkspacePersistenceFormat
+
+  /**
+   * Maximum compressed archive size accepted while saving or restoring.
+   *
+   * Defaults to `268_435_456` bytes (256 MiB) and must be a positive safe integer.
+   */
   readonly maxArchiveBytes?: number
+
+  /**
+   * Maximum number of selected archive entries, including the root where used.
+   *
+   * Defaults to `100_000` and must be a positive safe integer.
+   */
   readonly maxEntries?: number
+
+  /**
+   * Maximum total uncompressed bytes selected for one revision.
+   *
+   * Defaults to `1_073_741_824` bytes (1 GiB) and must be a positive safe integer.
+   */
   readonly maxExtractedBytes?: number
+
+  /**
+   * Parent directory for temporary per-acquisition materializations and archives.
+   *
+   * Defaults to `os.tmpdir()` and is resolved during provider construction.
+   */
   readonly temporaryDirectory?: string
 }
 
+/** Storage-layer identity exposed inside a Filesystem Workspace handle. */
 export interface FilesystemWorkspaceStorageHandle {
+  /** Host directory containing the acquired logical Workspace's storage objects. */
   readonly directory: string
+
+  /** Stable storage-handle discriminant. */
   readonly kind: "filesystem-workspace"
 }
 
+/**
+ * Persistent Workspace handle containing its staging directory, revision
+ * metadata, and {@link FilesystemWorkspaceStorageHandle}.
+ */
 export type FilesystemWorkspaceHandle = PersistentWorkspaceHandle<FilesystemWorkspaceStorageHandle>
 
 /**
  * Creates a safe staged Workspace whose revision store lives on this host.
+ *
+ * Each acquisition restores into a temporary directory, and configured saves
+ * publish an immutable revision plus a compare-and-swap index update. This is
+ * distinct from `localWorkspace()`, which exposes a directory directly.
+ *
+ * @param options Durable storage root, revision format, staging path, and limits.
  */
 export function filesystemWorkspace(
   options: FilesystemWorkspaceOptions
@@ -65,8 +120,15 @@ export function filesystemWorkspace(
  */
 export class FilesystemWorkspaceStorage implements WorkspaceStorageAdapter<FilesystemWorkspaceStorageHandle> {
   readonly #directory: string
+
+  /** Stable storage-adapter name included in provider references. */
   readonly name = "filesystem"
 
+  /**
+   * Captures and resolves a durable local storage root without creating it.
+   *
+   * @param options Directory beneath which logical Workspace namespaces live.
+   */
   constructor(options: FilesystemWorkspaceStorageOptions) {
     if (typeof options !== "object" || options === null) {
       throw new TypeError("Filesystem Workspace options must be an object")
@@ -83,12 +145,16 @@ export class FilesystemWorkspaceStorage implements WorkspaceStorageAdapter<Files
     this.#directory = path.resolve(options.directory)
   }
 
-  async acquire(request: {
-    readonly evaluationId: string
-    readonly id: string
-    readonly lock: boolean
-    readonly signal: AbortSignal
-  }): Promise<WorkspaceStorageLease<FilesystemWorkspaceStorageHandle>> {
+  /**
+   * Opens one logical Workspace namespace and optionally acquires its renewable
+   * cross-process writer lock.
+   *
+   * The returned lease implements atomic object replacement and conditional
+   * index writes. A held lock is released idempotently through `lease.release()`.
+   */
+  async acquire(
+    request: WorkspaceStorageAcquireRequest
+  ): Promise<WorkspaceStorageLease<FilesystemWorkspaceStorageHandle>> {
     request.signal.throwIfAborted()
     const root = path.join(this.#directory, workspaceStorageSegment(request.id))
     await mkdir(root, { recursive: true })

--- a/providers/workspaces/local/src/local-workspace-handle.ts
+++ b/providers/workspaces/local/src/local-workspace-handle.ts
@@ -2,6 +2,9 @@
  * Opaque same-host materialization identity returned by the local provider.
  */
 export interface LocalWorkspaceHandle {
+  /** Canonical host path of the acquired Workspace materialization. */
   readonly directory: string
+
+  /** Stable provider-handle discriminant. */
   readonly kind: "local-workspace"
 }

--- a/providers/workspaces/local/src/local-workspace-options.ts
+++ b/providers/workspaces/local/src/local-workspace-options.ts
@@ -4,6 +4,13 @@ import path from "node:path"
  * Local durable directory captured by `localWorkspace()`.
  */
 export interface LocalWorkspaceOptions {
+  /**
+   * Existing durable host directory exposed directly as the Workspace.
+   *
+   * Relative paths are resolved when {@link localWorkspace} is called. The
+   * factory does not touch the filesystem; acquisition later resolves symlinks
+   * and requires this path to exist as a directory.
+   */
   readonly directory: string
 }
 

--- a/providers/workspaces/local/src/local-workspace.ts
+++ b/providers/workspaces/local/src/local-workspace.ts
@@ -26,6 +26,13 @@ export type { LocalWorkspaceOptions } from "./local-workspace-options.js"
 
 /**
  * Creates a lazy provider for one existing durable local directory.
+ *
+ * The directory itself is the materialization, so changes are already durable
+ * and `save()` acts only as a lock-health barrier. Acquisitions request an
+ * exclusive renewable cross-process lock by default; `<Workspace lock={false}>`
+ * opts out for application-coordinated access.
+ *
+ * @param options Existing host directory to expose directly.
  */
 export function localWorkspace(options: LocalWorkspaceOptions): Readonly<WorkspaceProvider<LocalWorkspaceHandle>> {
   return defineWorkspaceProvider(new LocalWorkspaceProvider(parseLocalWorkspaceOptions(options)))

--- a/providers/workspaces/s3/src/s3-workspace-options.ts
+++ b/providers/workspaces/s3/src/s3-workspace-options.ts
@@ -13,14 +13,67 @@ const DEFAULT_PREFIX = "aml/workspaces"
  * S3-compatible archive storage configuration.
  */
 export interface S3WorkspaceOptions {
+  /** S3-compatible bucket used for every Workspace object operation. */
   readonly bucket: string
+
+  /**
+   * Preconstructed AWS SDK S3 client.
+   *
+   * Omitted by default and mutually exclusive with `config`. Inject this when
+   * the application owns client lifecycle, middleware, or credential wiring.
+   */
   readonly client?: S3Client
+
+  /**
+   * AWS SDK configuration used to construct an S3 client lazily.
+   *
+   * Omitted by default and mutually exclusive with `client`. Internally
+   * constructed clients default to region `us-east-1` before this overlay.
+   */
   readonly config?: S3ClientConfig
+
+  /**
+   * Representation used for new revisions.
+   *
+   * Defaults to `"archive"`; `"folder"` stores selected files as individual
+   * objects. Existing revisions retain and restore their recorded format.
+   */
   readonly format?: WorkspacePersistenceFormat
+
+  /**
+   * Maximum compressed archive size accepted while saving or restoring.
+   *
+   * Defaults to `268_435_456` bytes (256 MiB) and must be a positive safe integer.
+   */
   readonly maxArchiveBytes?: number
+
+  /**
+   * Maximum number of selected revision entries.
+   *
+   * Defaults to `100_000` and must be a positive safe integer.
+   */
   readonly maxEntries?: number
+
+  /**
+   * Maximum total uncompressed bytes selected for one revision.
+   *
+   * Defaults to `1_073_741_824` bytes (1 GiB) and must be a positive safe integer.
+   */
   readonly maxExtractedBytes?: number
+
+  /**
+   * Object-key namespace beneath the bucket.
+   *
+   * Defaults to `"aml/workspaces"`. It cannot start or end with `/`, contain an
+   * empty segment, or contain `.` or `..` traversal segments.
+   */
   readonly prefix?: string
+
+  /**
+   * Local parent directory for downloads, snapshots, and archive staging.
+   *
+   * Defaults to `os.tmpdir()` and is resolved when the provider is constructed.
+   */
   readonly temporaryDirectory?: string
 }
 

--- a/providers/workspaces/s3/src/s3-workspace-storage.ts
+++ b/providers/workspaces/s3/src/s3-workspace-storage.ts
@@ -23,9 +23,15 @@ import {
 import { S3WorkspaceLock } from "./s3-workspace-lock.js"
 import type { ParsedS3WorkspaceOptions } from "./s3-workspace-options.js"
 
+/** Provider handle identifying the S3 namespace used by one Workspace lease. */
 export interface S3WorkspaceStorageHandle {
+  /** Bucket containing this logical Workspace's persistence objects. */
   readonly bucket: string
+
+  /** Stable storage-handle discriminant. */
   readonly kind: "s3-workspace"
+
+  /** Configured object-key namespace shared by AML Workspace objects. */
   readonly prefix: string
 }
 

--- a/providers/workspaces/s3/src/s3-workspace.ts
+++ b/providers/workspaces/s3/src/s3-workspace.ts
@@ -3,6 +3,10 @@ import { createPersistentWorkspaceProvider, type PersistentWorkspaceHandle, type
 import { parseS3WorkspaceOptions, type S3WorkspaceOptions } from "./s3-workspace-options.js"
 import { S3WorkspaceStorage, type S3WorkspaceStorageHandle } from "./s3-workspace-storage.js"
 
+/**
+ * Persistent Workspace handle containing its staging directory, revision
+ * metadata, and S3 storage identity.
+ */
 export type S3WorkspaceHandle = PersistentWorkspaceHandle<S3WorkspaceStorageHandle>
 
 export type { S3WorkspaceOptions } from "./s3-workspace-options.js"
@@ -10,6 +14,13 @@ export type { S3WorkspaceStorageHandle } from "./s3-workspace-storage.js"
 
 /**
  * Creates an S3-compatible Workspace backed by shared AML persistence.
+ *
+ * Factory construction performs no network I/O. Acquisition lazily opens the
+ * client and storage namespace, restores the selected revision into a local
+ * staging directory, and optionally holds a renewable object-store lock through
+ * save and release.
+ *
+ * @param options Bucket, client configuration, object prefix, format, and limits.
  */
 export function s3Workspace(options: S3WorkspaceOptions): Readonly<WorkspaceProvider<S3WorkspaceHandle>> {
   const parsed = parseS3WorkspaceOptions(options)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -62,7 +62,8 @@
   },
   "scripts": {
     "build": "vite build",
-    "lint": "tsc --noEmit && oxlint .",
+    "docs:check": "node scripts/check-public-api-docs.ts",
+    "lint": "tsc --noEmit && oxlint . && npm run docs:check",
     "package:check": "node scripts/check-package.ts",
     "prepublishOnly": "npm run build && npm run package:check",
     "release": "release-it",

--- a/sdk/scripts/check-public-api-docs.ts
+++ b/sdk/scripts/check-public-api-docs.ts
@@ -1,0 +1,404 @@
+import { isAbsolute, relative, resolve, sep } from "node:path"
+
+import ts from "@typescript/typescript6"
+
+/** One undocumented declaration or member found on the public SDK type graph. */
+export interface DocumentationIssue {
+  /** Human-readable public path to the undocumented declaration. */
+  readonly label: string
+
+  /** Workspace-relative source location of the declaration. */
+  readonly location: string
+}
+
+/**
+ * Audits exported declarations and every locally owned type reachable from them.
+ *
+ * External declaration files remain owned by their dependencies. Local type
+ * references and inheritance are followed recursively with cycle protection so
+ * a documented public property cannot conceal an undocumented nested shape.
+ */
+export class PublicApiDocumentationChecker {
+  readonly #checkedDeclarations = new Set<ts.Node>()
+  readonly #checkedTypes = new Set<ts.TypeNode>()
+  readonly #issues: DocumentationIssue[] = []
+  readonly #program: ts.Program
+  readonly #typeChecker: ts.TypeChecker
+  readonly #workspaceDirectory: string
+
+  /** Creates one checker for a configured TypeScript program. */
+  constructor(program: ts.Program, workspaceDirectory: string) {
+    this.#program = program
+    this.#typeChecker = program.getTypeChecker()
+    this.#workspaceDirectory = workspaceDirectory
+  }
+
+  /** Returns every documentation issue reachable from the supplied entrypoints. */
+  check(entrypoints: readonly string[]): readonly DocumentationIssue[] {
+    for (const entrypoint of entrypoints) {
+      const source = this.#program.getSourceFile(entrypoint)
+
+      if (source === undefined) {
+        throw new Error(`Public API documentation check could not load ${entrypoint}`)
+      }
+
+      const module = this.#typeChecker.getSymbolAtLocation(source)
+
+      if (module === undefined) {
+        throw new Error(`Public API documentation check could not resolve ${entrypoint}`)
+      }
+
+      for (const exported of this.#typeChecker.getExportsOfModule(module)) {
+        const resolved = this.#resolveSymbol(exported)
+        const declarations = resolved.getDeclarations() ?? exported.getDeclarations() ?? []
+
+        for (const declaration of declarations) {
+          this.#checkDeclaration(declaration, exported.name, declarations)
+        }
+      }
+    }
+
+    return Object.freeze(
+      [...this.#issues].sort(
+        (left, right) => left.location.localeCompare(right.location) || left.label.localeCompare(right.label)
+      )
+    )
+  }
+
+  #checkDeclaration(
+    declaration: ts.Declaration,
+    label: string,
+    siblingDeclarations: readonly ts.Declaration[] = []
+  ): void {
+    if (this.#checkedDeclarations.has(declaration) || isOverloadImplementation(declaration, siblingDeclarations)) {
+      return
+    }
+
+    this.#checkedDeclarations.add(declaration)
+    this.#requireDocumentation(declaration, label)
+    this.#checkTypeParameters(declaration, label)
+
+    if (ts.isInterfaceDeclaration(declaration) || ts.isClassDeclaration(declaration)) {
+      for (const heritageClause of declaration.heritageClauses ?? []) {
+        for (const heritageType of heritageClause.types) {
+          for (const typeArgument of heritageType.typeArguments ?? []) {
+            this.#checkType(typeArgument, `${label} base`)
+          }
+          this.#checkReferencedNode(heritageType.expression, `${label} base`)
+        }
+      }
+
+      for (const member of declaration.members) {
+        if (!isPublicMember(member)) continue
+        this.#checkMember(member, `${label}.${memberName(member)}`, declaration.members)
+      }
+      return
+    }
+
+    if (ts.isEnumDeclaration(declaration)) {
+      for (const member of declaration.members) {
+        this.#requireDocumentation(member, `${label}.${member.name.getText()}`)
+      }
+      return
+    }
+
+    if (ts.isTypeAliasDeclaration(declaration)) {
+      this.#checkType(declaration.type, label)
+      return
+    }
+
+    if (ts.isModuleDeclaration(declaration) && declaration.body !== undefined) {
+      this.#checkModuleBody(declaration.body, label)
+      return
+    }
+
+    if (ts.isFunctionDeclaration(declaration)) {
+      for (const parameter of declaration.parameters) {
+        if (parameter.type !== undefined) this.#checkType(parameter.type, `${label} parameter`)
+      }
+      if (declaration.type !== undefined) this.#checkType(declaration.type, `${label} result`)
+      return
+    }
+
+    if (ts.isVariableDeclaration(declaration) && declaration.type !== undefined) {
+      this.#checkType(declaration.type, label)
+    }
+  }
+
+  #checkModuleBody(body: ts.ModuleBody, label: string): void {
+    if (ts.isModuleDeclaration(body)) {
+      this.#checkDeclaration(body, `${label}.${body.name.getText()}`)
+      return
+    }
+
+    if (!ts.isModuleBlock(body)) return
+
+    for (const statement of body.statements) {
+      if (!isExported(statement)) continue
+
+      if (
+        ts.isClassDeclaration(statement) ||
+        ts.isEnumDeclaration(statement) ||
+        ts.isFunctionDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isModuleDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement)
+      ) {
+        this.#checkDeclaration(statement, `${label}.${declarationName(statement)}`)
+        continue
+      }
+
+      if (ts.isVariableStatement(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          this.#checkDeclaration(declaration, `${label}.${declaration.name.getText()}`)
+        }
+      }
+    }
+  }
+
+  #checkMember(
+    member: ts.ClassElement | ts.TypeElement,
+    label: string,
+    siblings: readonly (ts.ClassElement | ts.TypeElement)[]
+  ): void {
+    if (isOverloadImplementation(member, siblings)) return
+
+    this.#requireDocumentation(member, label)
+    this.#checkTypeParameters(member, label)
+
+    if (
+      ts.isCallSignatureDeclaration(member) ||
+      ts.isConstructSignatureDeclaration(member) ||
+      ts.isConstructorDeclaration(member) ||
+      ts.isMethodDeclaration(member) ||
+      ts.isMethodSignature(member) ||
+      ts.isSetAccessorDeclaration(member)
+    ) {
+      for (const parameter of member.parameters) {
+        if (parameter.type !== undefined) this.#checkType(parameter.type, `${label} parameter`)
+      }
+    }
+
+    if (
+      (ts.isCallSignatureDeclaration(member) ||
+        ts.isConstructSignatureDeclaration(member) ||
+        ts.isGetAccessorDeclaration(member) ||
+        ts.isIndexSignatureDeclaration(member) ||
+        ts.isMethodDeclaration(member) ||
+        ts.isMethodSignature(member) ||
+        ts.isPropertyDeclaration(member) ||
+        ts.isPropertySignature(member)) &&
+      member.type !== undefined
+    ) {
+      this.#checkType(member.type, label)
+    }
+  }
+
+  #checkType(type: ts.TypeNode, label: string): void {
+    if (this.#checkedTypes.has(type)) return
+    this.#checkedTypes.add(type)
+
+    if (ts.isTypeLiteralNode(type)) {
+      for (const member of type.members) {
+        this.#checkMember(member, `${label}.${memberName(member)}`, type.members)
+      }
+      return
+    }
+
+    if (ts.isFunctionTypeNode(type) || ts.isConstructorTypeNode(type)) {
+      this.#checkTypeParameters(type, label)
+      for (const parameter of type.parameters) {
+        if (parameter.type !== undefined) this.#checkType(parameter.type, `${label} parameter`)
+      }
+      this.#checkType(type.type, `${label} result`)
+      return
+    }
+
+    if (ts.isMappedTypeNode(type)) {
+      if (type.typeParameter.constraint !== undefined) {
+        this.#checkType(type.typeParameter.constraint, `${label} key`)
+      }
+      if (type.nameType !== undefined) this.#checkType(type.nameType, `${label} key`)
+      if (type.type !== undefined) this.#checkType(type.type, `${label} value`)
+      return
+    }
+
+    if (ts.isTypeReferenceNode(type)) {
+      for (const typeArgument of type.typeArguments ?? []) {
+        this.#checkType(typeArgument, label)
+      }
+      this.#checkReferencedNode(type.typeName, label)
+      return
+    }
+
+    ts.forEachChild(type, child => {
+      if (ts.isTypeNode(child)) this.#checkType(child, label)
+    })
+  }
+
+  #checkTypeParameters(node: ts.Node, label: string): void {
+    const typeParameters = (node as ts.Node & { readonly typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> })
+      .typeParameters
+
+    for (const typeParameter of typeParameters ?? []) {
+      if (typeParameter.constraint !== undefined) {
+        this.#checkType(typeParameter.constraint, `${label} type parameter`)
+      }
+      if (typeParameter.default !== undefined) {
+        this.#checkType(typeParameter.default, `${label} type parameter`)
+      }
+    }
+  }
+
+  #checkReferencedNode(node: ts.Node, label: string): void {
+    const symbol = this.#typeChecker.getSymbolAtLocation(node)
+    if (symbol === undefined) return
+
+    const resolved = this.#resolveSymbol(symbol)
+    const declarations = resolved.getDeclarations() ?? symbol.getDeclarations() ?? []
+
+    for (const declaration of declarations) {
+      if (!this.#isWorkspaceDeclaration(declaration) || !isAuditableTypeDeclaration(declaration)) continue
+      this.#checkDeclaration(declaration, `${label} (${resolved.name})`, declarations)
+    }
+  }
+
+  #resolveSymbol(symbol: ts.Symbol): ts.Symbol {
+    return symbol.flags & ts.SymbolFlags.Alias ? this.#typeChecker.getAliasedSymbol(symbol) : symbol
+  }
+
+  #isWorkspaceDeclaration(declaration: ts.Declaration): boolean {
+    const source = declaration.getSourceFile()
+    const path = relative(this.#workspaceDirectory, source.fileName)
+
+    if (path === "" || path === ".." || path.startsWith(`..${sep}`) || isAbsolute(path)) return false
+    return !path.split(sep).includes("node_modules")
+  }
+
+  #requireDocumentation(node: ts.Node, label: string): void {
+    if (hasDocumentation(node)) return
+
+    this.#issues.push({
+      label: `${label} is missing documentation`,
+      location: sourceLocation(node, this.#workspaceDirectory),
+    })
+  }
+}
+
+const packageDirectory = resolve(import.meta.dirname, "..")
+const workspaceDirectory = resolve(packageDirectory, "..")
+const configPath = resolve(packageDirectory, "tsconfig.build.json")
+const publicEntrypoints = ["src/index.ts", "src/testing.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts"] as const
+
+/** Runs the repository's public SDK documentation gate. */
+function runPublicApiDocumentationCheck(): void {
+  const config = ts.readConfigFile(configPath, ts.sys.readFile)
+
+  if (config.error !== undefined) {
+    throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, "\n"))
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, packageDirectory, undefined, configPath)
+  const program = ts.createProgram({ options: parsed.options, rootNames: parsed.fileNames })
+  const checker = new PublicApiDocumentationChecker(program, workspaceDirectory)
+  const issues = checker.check(publicEntrypoints.map(entrypoint => resolve(packageDirectory, entrypoint)))
+
+  if (issues.length > 0) {
+    const details = issues.map(issue => `- ${issue.location} ${issue.label}`).join("\n")
+    throw new Error(
+      `Public API declarations and their locally owned public shapes require adjacent JSDoc blocks:\n${details}`
+    )
+  }
+
+  console.log("Public SDK declarations and locally owned nested shapes have JSDoc coverage")
+}
+
+function hasDocumentation(node: ts.Node): boolean {
+  let current: ts.Node | undefined = node
+
+  while (current !== undefined) {
+    if (ts.getJSDocCommentsAndTags(current).some(comment => ts.isJSDoc(comment))) {
+      return true
+    }
+
+    if (ts.isStatement(current) || ts.isClassElement(current) || ts.isTypeElement(current)) {
+      return false
+    }
+
+    current = current.parent
+  }
+
+  return false
+}
+
+function isOverloadImplementation(declaration: ts.Declaration, siblings: readonly ts.Declaration[]): boolean {
+  if (!hasBody(declaration)) return false
+
+  return siblings.some(
+    sibling =>
+      sibling !== declaration &&
+      sibling.kind === declaration.kind &&
+      declarationName(sibling) === declarationName(declaration) &&
+      !hasBody(sibling)
+  )
+}
+
+function hasBody(declaration: ts.Declaration): boolean {
+  return (
+    (ts.isConstructorDeclaration(declaration) ||
+      ts.isFunctionDeclaration(declaration) ||
+      ts.isMethodDeclaration(declaration)) &&
+    declaration.body !== undefined
+  )
+}
+
+function isPublicMember(member: ts.ClassElement | ts.TypeElement): boolean {
+  if (!ts.isClassElement(member)) return true
+  if (member.name !== undefined && ts.isPrivateIdentifier(member.name)) return false
+  return (ts.getCombinedModifierFlags(member) & ts.ModifierFlags.Private) === 0
+}
+
+function isExported(statement: ts.Statement): boolean {
+  const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined
+  return modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true
+}
+
+function isAuditableTypeDeclaration(declaration: ts.Declaration): boolean {
+  return (
+    ts.isClassDeclaration(declaration) ||
+    ts.isEnumDeclaration(declaration) ||
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isModuleDeclaration(declaration) ||
+    ts.isTypeAliasDeclaration(declaration)
+  )
+}
+
+function declarationName(declaration: ts.Declaration): string {
+  if (ts.isConstructorDeclaration(declaration)) return "constructor"
+  if (
+    ts.isClassDeclaration(declaration) ||
+    ts.isEnumDeclaration(declaration) ||
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isModuleDeclaration(declaration) ||
+    ts.isTypeAliasDeclaration(declaration) ||
+    ts.isVariableDeclaration(declaration)
+  ) {
+    if (declaration.name !== undefined) return declaration.name.getText()
+  }
+  return ts.SyntaxKind[declaration.kind]
+}
+
+function memberName(member: ts.ClassElement | ts.TypeElement): string {
+  if (member.name !== undefined) return member.name.getText()
+  return ts.SyntaxKind[member.kind]
+}
+
+function sourceLocation(node: ts.Node, workspaceDirectory: string): string {
+  const source = node.getSourceFile()
+  const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1
+  return `${relative(workspaceDirectory, source.fileName)}:${line}`
+}
+
+if (import.meta.main) runPublicApiDocumentationCheck()

--- a/sdk/src/components/agent/abstract-agent-provider.ts
+++ b/sdk/src/components/agent/abstract-agent-provider.ts
@@ -16,8 +16,15 @@ import { executeAgentProviderSession } from "./execute-agent-provider-session.js
  * response selection, and failure-safe invocation cleanup.
  */
 export abstract class AbstractAgentProvider<Name extends string> implements AgentProvider {
+  /** Stable non-empty normalized identifier used in diagnostics and traces. */
   readonly name: Name
 
+  /**
+   * Creates a provider base with a literal name retained in the subclass type.
+   *
+   * Concrete subclasses should expose their own application-facing factory and
+   * implement `openSession` for exactly one AML Agent invocation.
+   */
   protected constructor(name: Name) {
     this.name = name
   }
@@ -64,6 +71,10 @@ export abstract class AbstractAgentProvider<Name extends string> implements Agen
 
   /**
    * Attaches session-wide capabilities and creates one fresh conversation.
+   *
+   * The returned session is consumed exactly once. `AbstractAgentProvider`
+   * guarantees ordered turns, cancellation notification, and `close()` after
+   * success or failure.
    */
   protected abstract openSession(request: AgentRequest, context: AgentExecutionContext): Promise<AgentProviderSession>
 }

--- a/sdk/src/components/agent/acp-agent-provider.ts
+++ b/sdk/src/components/agent/acp-agent-provider.ts
@@ -33,13 +33,32 @@ import { spawnLocalProcess } from "./spawn-local-process.js"
  * Execution environment prepared once for an ACP Agent profile.
  */
 export interface AcpAgentLaunchContext {
-  /** Invocation-owned MCP server hosting AML JavaScript Tools and structured output. */
+  /**
+   * Invocation-owned MCP server hosting AML JavaScript Tools and structured output.
+   *
+   * Omitted when the request grants no JavaScript Tools and asks for no
+   * structured output.
+   */
   readonly amlMcpServerName?: string
+
+  /** Physical working directory in the host process or active Sandbox. */
   readonly cwd: string
+
   /** Whether the launched process inherits the AML host's `process.env`. */
   readonly inheritsProcessEnvironment: boolean
+
+  /** ACP transport descriptors already mapped from the Agent's MCP grants. */
   readonly mcpServers: readonly McpServer[]
+
+  /** Complete provider-neutral Agent request used to derive vendor settings. */
   readonly request: Readonly<AgentRequest>
+
+  /**
+   * Fresh writable directory owned by this invocation.
+   *
+   * Profiles may place configuration and credential-pointer files here. AML
+   * removes the directory during session cleanup.
+   */
   readonly stateDirectory: string
 }
 
@@ -47,8 +66,13 @@ export interface AcpAgentLaunchContext {
  * Invocation-private file requested by an Agent profile.
  */
 export interface AcpAgentLaunchFile {
+  /** UTF-8 contents written before the Agent process starts. */
   readonly content: string
+
+  /** Whether AML adds executable permission after writing; defaults to `false`. */
   readonly executable?: boolean
+
+  /** Portable relative path beneath the invocation `stateDirectory`. */
   readonly path: string
 }
 
@@ -56,16 +80,42 @@ export interface AcpAgentLaunchFile {
  * Process and protocol settings supplied by one thin ACP Agent profile.
  */
 export interface AcpAgentLaunch {
+  /** Literal process arguments; defaults to an empty array. */
   readonly args?: readonly string[]
+
+  /** ACP authentication method selected after initialization, when required. */
   readonly authenticationMethodId?: string
+
+  /** Executable started through the host or active Sandbox process runtime. */
   readonly command: string
+
+  /** ACP session configuration values applied before prompting. */
   readonly configuration?: readonly AcpSessionConfiguration[]
+
+  /** Environment entries supplied to the launched process. */
   readonly env?: Readonly<Record<string, string>>
+
+  /** Invocation-private files materialized before process startup. */
   readonly files?: readonly AcpAgentLaunchFile[]
+
+  /** Text prepended only to the initial authored prompt, when configured. */
   readonly initialPromptPrefix?: string
+
+  /** Maps AML permission requests onto ACP permission decisions. */
   readonly permissionPolicy: AcpPermissionPolicy
+
+  /**
+   * Complete ACP MCP list used for session creation.
+   *
+   * Omission uses the mapped `AcpAgentLaunchContext.mcpServers`; supplying this
+   * field replaces that list and is useful only for profile-specific mapping.
+   */
   readonly sessionMcpServers?: readonly McpServer[]
+
+  /** Profile-specific instruction used for AML's structured-result Tool turn. */
   readonly structuredOutputInstruction?: string
+
+  /** Optional final ACP text transformation applied before AML returns a turn. */
   readonly transformText?: AcpSessionTextTransform
 }
 
@@ -73,10 +123,21 @@ export interface AcpAgentLaunch {
  * Agent-specific configuration retained outside the shared ACP lifecycle.
  */
 export interface AcpAgentProfile<Name extends string> {
+  /** Literal provider name exposed by the resulting Agent provider. */
   readonly name: Name
+
+  /**
+   * Host working directory used outside a Sandbox.
+   *
+   * `undefined` defaults to `process.cwd()`. An active Sandbox supplies its own
+   * physical cwd and ignores this host-only setting.
+   */
   readonly workingDirectory: string | undefined
 
+  /** Builds invocation-specific process and ACP settings without starting work. */
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch>
+
+  /** Reports whether this profile can map one provider-native MCP server name. */
   supportsNamedMcpServer?(name: string): boolean
 }
 
@@ -159,11 +220,20 @@ class AcpAgentProvider<Name extends string> extends AbstractAgentProvider<Name> 
 }
 
 /**
- * Defines an Agent provider backed by AML's shared ACP lifecycle.
+ * Defines an immutable Agent provider backed by AML's shared ACP lifecycle.
+ *
+ * The shared implementation owns process startup, Sandbox execution, MCP Tool
+ * bridging, ordered turns, cancellation, structured output, and cleanup. The
+ * profile owns only vendor-specific launch and capability mapping.
  */
 export function defineAcpAgentProvider<Name extends string>(
   profile: Readonly<AcpAgentProfile<Name>>
-): Readonly<AgentProvider & { readonly name: Name }> {
+): Readonly<
+  AgentProvider & {
+    /** Exact provider name captured from the ACP profile. */
+    readonly name: Name
+  }
+> {
   return defineAgentProvider(new AcpAgentProvider(profile))
 }
 

--- a/sdk/src/components/agent/acp-agent-session.ts
+++ b/sdk/src/components/agent/acp-agent-session.ts
@@ -45,13 +45,23 @@ export type AcpPermissionPolicy = PermissionOptionKind
  */
 export type AcpSessionConfiguration =
   | {
+      /** Semantic ACP option category selected when ids vary by implementation. */
       readonly category: string
+
+      /** Excludes id-based matching from the category branch. */
       readonly id?: never
+
+      /** Boolean value or advertised selection id applied to the option. */
       readonly value: boolean | string
     }
   | {
+      /** Excludes category-based matching from the id branch. */
       readonly category?: never
+
+      /** Stable ACP session option id to configure. */
       readonly id: string
+
+      /** Boolean value or advertised selection id applied to the option. */
       readonly value: boolean | string
     }
 

--- a/sdk/src/components/agent/agent-execution-context.ts
+++ b/sdk/src/components/agent/agent-execution-context.ts
@@ -6,8 +6,25 @@ import type { SandboxSession } from "../sandbox/sandbox-provider.js"
  * Evaluation-scoped dependencies supplied to one provider session.
  */
 export interface AgentExecutionContext {
+  /** Evaluation event subscription boundary shared with the provider session. */
   readonly events: AmlEventSubscriber
+
+  /**
+   * Effective Sandbox session for model-controlled execution, when present.
+   *
+   * Providers must return `true` from `supportsSandbox` before AML supplies a
+   * Sandbox context to `run`.
+   */
   readonly sandbox?: SandboxSession
+
+  /**
+   * Invocation signal aborted by caller cancellation or an Agent timeout.
+   *
+   * Providers must stop pending work cooperatively and must not replace the
+   * signal's reason with a provider-native cancellation error.
+   */
   readonly signal: AbortSignal
+
+  /** Trace identity of the enclosing AML Agent boundary. */
   readonly trace: AmlTraceIdentity
 }

--- a/sdk/src/components/agent/agent-output-request.ts
+++ b/sdk/src/components/agent/agent-output-request.ts
@@ -4,6 +4,14 @@ import type { AmlJsonValue } from "../../core/aml-json-value.js"
  * Portable structured-output declaration supplied to an Agent provider.
  */
 export interface AgentOutputRequest {
+  /**
+   * Read-only JSON Schema shown to the model-facing provider integration.
+   *
+   * AML retains the authoritative Standard Schema validator separately and
+   * validates the provider's returned `structured` value at the SDK boundary.
+   */
   readonly jsonSchema: Readonly<Record<string, AmlJsonValue>>
+
+  /** Discriminant for AML's portable JSON structured-output request. */
   readonly type: "json"
 }

--- a/sdk/src/components/agent/agent-provider-session.ts
+++ b/sdk/src/components/agent/agent-provider-session.ts
@@ -6,9 +6,20 @@ import type { AgentResponse } from "./agent-response.js"
  * One ordered authored input translated by a provider-owned session.
  */
 export interface AgentProviderTurn {
+  /** Zero-based authored turn index; `0` is the initial prompt. */
   readonly index: number
+
+  /** Whether this is the last authored turn in the retained conversation. */
   readonly isFinal: boolean
+
+  /**
+   * Structured-output request attached only to the final authored turn.
+   *
+   * Omitted for text Agents and for every non-final follow-up turn.
+   */
   readonly output?: AgentOutputRequest
+
+  /** Non-empty provider input for this turn, already trimmed by AML. */
   readonly prompt: string
 }
 
@@ -22,16 +33,26 @@ export interface AgentProviderSession {
   /**
    * Requests provider-native cancellation when the active operation cannot
    * rely on `AgentExecutionContext.signal` alone.
+   *
+   * AML calls this at most once, awaits it before `close`, and preserves the
+   * caller's abort reason if this method fails.
    */
   abort?(): Promise<void>
 
   /**
    * Releases every invocation-owned provider resource.
+   *
+   * AML invokes this exactly once after session validation and after all started
+   * turn or abort work settles. Implementations should be safe after partial
+   * session initialization.
    */
   close(): Promise<void>
 
   /**
    * Executes one authored turn in the retained provider conversation.
+   *
+   * Calls are serial and preserve `turn.index`. The returned response belongs
+   * to this turn; AML returns only the final turn response to the workflow.
    */
   runTurn(turn: Readonly<AgentProviderTurn>, context: AgentExecutionContext): Promise<AgentResponse>
 }

--- a/sdk/src/components/agent/agent-provider.ts
+++ b/sdk/src/components/agent/agent-provider.ts
@@ -7,20 +7,28 @@ import type { AgentResponse } from "./agent-response.js"
  * Executes one fully assembled Agent request through a configured harness.
  */
 export interface AgentProvider {
+  /**
+   * Non-empty normalized provider identifier used in errors and trace metadata.
+   *
+   * The name identifies the adapter, not a model or individual session.
+   */
   readonly name: string
 
   /**
    * Executes one isolated provider session for the complete authored turn plan.
    *
    * The initial prompt and every request FollowUp share provider history and
-   * session-wide capabilities; only the final response is returned to AML.
+   * session-wide capabilities; only the final response is returned to AML. The
+   * method must honor `context.signal` and settle only after invocation-owned
+   * cleanup completes.
    */
   run(request: AgentRequest, context: AgentExecutionContext): Promise<AgentResponse>
 
   /**
    * Confirms that model-controlled actions honor one effective Sandbox.
    *
-   * A provider without this handshake cannot execute inside `<Sandbox>`.
+   * A provider without this handshake cannot execute inside `<Sandbox>`. The
+   * check must describe enforcement, not merely whether a process can start.
    */
   supportsSandbox?(sandbox: SandboxSession): boolean
 }

--- a/sdk/src/components/agent/agent-request.ts
+++ b/sdk/src/components/agent/agent-request.ts
@@ -10,17 +10,47 @@ import type { AgentPermissions } from "./agent.js"
 export interface AgentRequest {
   /**
    * Ordered later user inputs executed in the same provider session.
+   *
+   * Omitted when the Agent has no `FollowUp` children. Each value is non-empty
+   * trimmed text and shares the initial turn's capabilities and history.
    */
   readonly followUps?: readonly string[]
+
+  /** Agent-local MCP grants in authored order; empty when none were declared. */
   readonly mcpServers: readonly AgentMcpServer[]
+
+  /**
+   * Provider-owned model identifier, or `undefined` to use the provider default.
+   * AML does not normalize or validate provider-specific model names.
+   */
   readonly model?: string
+
   /** Optional authored metadata used only for diagnostics and tracing. */
   readonly name?: string
+
+  /** Portable structured-output request for the final turn, when configured. */
   readonly output?: AgentOutputRequest
+
+  /** Fully defaulted native harness permission request for this session. */
   readonly permissions: AgentPermissions
+
+  /** Trimmed initial user prompt; it may be empty when the Agent has no text. */
   readonly prompt: string
+
+  /** Joined runtime, Agent, and child `System` text; empty when none exists. */
   readonly system: string
+
+  /** Positive safe-integer Agent timeout in milliseconds, when configured. */
   readonly timeoutMs?: number
+
+  /** Agent-local JavaScript Tool grants in authored order; empty when absent. */
   readonly tools: readonly AgentTool[]
+
+  /**
+   * Trace identity assigned by AML to the Agent request.
+   *
+   * Runtime-created requests include it. The property remains optional for
+   * compatibility with independently authored provider requests.
+   */
   readonly trace?: AmlTraceIdentity
 }

--- a/sdk/src/components/agent/agent-response.ts
+++ b/sdk/src/components/agent/agent-response.ts
@@ -13,7 +13,17 @@ export interface AgentResponse {
 
   /**
    * Provider-native structured value when the request declared JSON output.
+   *
+   * AML rejects omission for a structured request and validates this value with
+   * the application-owned schema before exposing it to composition.
    */
   readonly structured?: unknown
+
+  /**
+   * Concatenated assistant text for the completed turn.
+   *
+   * This field is required even when the provider also returns `structured` or
+   * `messages`; an empty string is a valid text result.
+   */
   readonly text: string
 }

--- a/sdk/src/components/agent/agent-timeout.ts
+++ b/sdk/src/components/agent/agent-timeout.ts
@@ -2,8 +2,10 @@ const AML_AGENT_TIMEOUT_ERROR = Symbol.for("@aml-jsx/sdk/agent-timeout-error")
 
 /** Error used as the cancellation reason when an Agent execution expires. */
 export class AgentTimeoutError extends Error {
+  /** Positive safe-integer timeout that expired, in milliseconds. */
   readonly timeoutMs: number
 
+  /** Creates the abort reason used when one Agent-local deadline expires. */
   constructor(timeoutMs: number) {
     super(`<Agent> execution timed out after ${timeoutMs}ms`)
     this.name = "AgentTimeoutError"

--- a/sdk/src/components/agent/agent.tsx
+++ b/sdk/src/components/agent/agent.tsx
@@ -9,33 +9,126 @@ import type { AgentProvider } from "./agent-provider.js"
  * authoritative confinement boundary.
  */
 export interface AgentPermissions {
+  /**
+   * Filesystem authority requested from the native Agent harness.
+   *
+   * Defaults to `"read-write"`. A read-only enclosing Sandbox always narrows
+   * this value to `"read-only"`; this setting cannot widen Sandbox access.
+   */
   readonly filesystem: "read-only" | "read-write"
+
+  /**
+   * Whether the native Agent harness may use network capabilities.
+   *
+   * Defaults to `true`. Provider support and Sandbox or deployment network
+   * policy remain authoritative.
+   */
   readonly network: boolean
+
+  /**
+   * Whether the native Agent harness may execute shell commands.
+   *
+   * Defaults to `true`. This is a provider control, not an isolation boundary;
+   * use an enforcing Sandbox when command execution needs confinement.
+   */
   readonly shell: boolean
 }
 
-/** Optional overrides for AML's optimistic native-capability defaults. */
+/**
+ * Optional overrides for AML's optimistic native-capability defaults.
+ *
+ * Omitted fields retain the defaults described by {@link AgentPermissions}.
+ */
 export type AgentPermissionOverrides = Partial<AgentPermissions>
 
 /**
  * Provider selection, prompt children, and optional Agent-level overrides.
  */
 export interface AgentProps {
+  /**
+   * Initial prompt content and Agent-scoped descriptors.
+   *
+   * AML resolves nested values before opening the provider session. Ordinary
+   * text forms the initial prompt; `System`, `Skill`, `Tool`, `Mcp`, and
+   * `FollowUp` children contribute to their dedicated parts of the request.
+   * Omission produces an empty initial prompt.
+   */
   readonly children?: AmlRenderable
+
+  /**
+   * Agent-local logical working directory within an enclosing Sandbox.
+   *
+   * The value is a portable relative path resolved from the active Sandbox
+   * root. It defaults to the Sandbox cwd and is invalid without a Sandbox.
+   */
   readonly cwd?: string
+
+  /**
+   * Provider-owned model identifier for this session.
+   *
+   * AML passes the value through unchanged. When omitted, the selected Agent
+   * provider chooses its configured or native default model.
+   */
   readonly model?: string
+
+  /**
+   * Non-empty normalized diagnostic label for this Agent occurrence.
+   *
+   * Names need not be unique and appear only in traces and error messages;
+   * AML never adds them to model prompts. Omission leaves the Agent unnamed.
+   */
   readonly name?: string
+
+  /**
+   * Native harness capability overrides for this session.
+   *
+   * Omitted fields default to read-write filesystem, network, and shell access.
+   * Sandbox policy may narrow the effective filesystem authority.
+   */
   readonly permissions?: AgentPermissionOverrides
+
+  /**
+   * Agent provider that owns this session's model and harness lifecycle.
+   *
+   * When omitted, AML uses `AmlRuntimeOptions.agentProvider`. Evaluation fails
+   * if neither location supplies a provider.
+   */
   readonly provider?: AgentProvider
+
+  /**
+   * Standard Schema used to request and validate structured final output.
+   *
+   * The validated value is rendered as canonical JSON text in ordinary AML
+   * composition. Use component-local `evaluate(value, schema)` instead when
+   * application code needs the schema-inferred value directly.
+   */
   readonly schema?: AmlModelSchema<unknown, unknown>
+
+  /**
+   * Fixed system text for this Agent.
+   *
+   * It follows runtime-wide system text and precedes child `System` fragments.
+   * Empty or omitted text contributes no system fragment.
+   */
   readonly system?: string
+
+  /**
+   * Maximum provider-session duration in milliseconds.
+   *
+   * A supplied value must be a positive safe integer. The timer starts after
+   * the Agent obtains a scheduler slot; expiry aborts the provider session and
+   * AML still awaits provider cleanup. Omission applies no Agent-local timeout.
+   */
   readonly timeoutMs?: number
 }
 
 /**
- * Declares one provider-backed Agent session.
+ * Declares one provider-backed Agent session and contributes its final text.
  *
- * AmlRuntime intercepts this boundary after constructing its JSX descriptor.
+ * AML resolves prompt fragments and capability descriptors before opening the
+ * session, runs the initial turn and ordered follow-ups in one provider-owned
+ * history, then awaits cleanup before the component settles. Direct invocation
+ * is invalid; `AmlRuntime` evaluates the JSX descriptor.
  */
 export function Agent(_props: AgentProps): never {
   throw new Error("<Agent> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/agent/aml-model-schema.ts
+++ b/sdk/src/components/agent/aml-model-schema.ts
@@ -4,7 +4,13 @@ import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/sp
  * Structured model-output schema accepted by component-local `evaluate()`.
  *
  * Standard Schema owns validation and output inference. Standard JSON Schema
- * supplies the portable model-facing declaration from the same source.
+ * supplies the portable model-facing declaration from the same source. The
+ * schema is forwarded to the selected Agent as its structured-output contract,
+ * then AML validates the provider result and returns the Standard Schema output
+ * type. A schema implementing only one of these standards is not sufficient.
+ *
+ * @typeParam Input Value accepted by the schema before validation or transformation.
+ * @typeParam Output Value returned after successful validation or transformation.
  */
 export type AmlModelSchema<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output> &
   StandardJSONSchemaV1<Input, Output>

--- a/sdk/src/components/agent/create-agent-provider-turns.ts
+++ b/sdk/src/components/agent/create-agent-provider-turns.ts
@@ -5,7 +5,10 @@ import type { AgentRequest } from "./agent-request.js"
  * Normalizes one provider request into the exact authored turn order.
  *
  * Provider adapters may use this independently when they expose a lower-level
- * session test seam outside `AbstractAgentProvider`.
+ * session test seam outside `AbstractAgentProvider`. The initial prompt becomes
+ * index `0`; follow-ups follow in order; only the final turn receives the
+ * request's structured-output declaration. The returned array and turns are
+ * frozen.
  */
 export function createAgentProviderTurns(
   request: AgentRequest,

--- a/sdk/src/components/agent/define-agent-provider.ts
+++ b/sdk/src/components/agent/define-agent-provider.ts
@@ -5,7 +5,9 @@ import { validateAgentProvider } from "./validate-agent-provider.js"
  * Finalizes one provider implementation as an immutable AML adapter.
  *
  * Names must already be normalized so the returned runtime value keeps the
- * implementation's exact inferred TypeScript type.
+ * implementation's exact inferred TypeScript type. AML validates `name`, `run`,
+ * and optional `supportsSandbox`, then shallow-freezes the original object;
+ * provider-owned nested state is not cloned or frozen.
  */
 export function defineAgentProvider<const Provider extends AgentProvider>(
   implementation: Provider

--- a/sdk/src/components/agent/execute-agent-provider-session.ts
+++ b/sdk/src/components/agent/execute-agent-provider-session.ts
@@ -7,6 +7,11 @@ import { AgentTimeoutError } from "./agent-timeout.js"
 /**
  * Executes a captured provider session and preserves lifecycle failures in
  * deterministic execution, abort, then cleanup order.
+ *
+ * Turns run serially. Cancellation requests optional provider `abort()`, waits
+ * for it, and then invokes `close()` exactly once. Multiple independent errors
+ * are retained in lifecycle order through `AggregateError`; only the final turn
+ * response is returned.
  */
 export async function executeAgentProviderSession(
   value: AgentProviderSession,

--- a/sdk/src/components/agent/spawn-local-process.ts
+++ b/sdk/src/components/agent/spawn-local-process.ts
@@ -3,11 +3,30 @@ import { Readable, Writable } from "node:stream"
 
 import type { SandboxProcess, SandboxProcessExit } from "../sandbox/sandbox-runtime.js"
 
+/** Process startup, cancellation, and cleanup options for trusted host execution. */
 export interface LocalProcessOptions {
+  /**
+   * Optional asynchronous hook invoked before AML terminates the process tree.
+   *
+   * It may release protocol state or request graceful shutdown. Failure is
+   * retained alongside any later operating-system termination failure.
+   */
   readonly beforeKill?: () => Promise<void>
+
+  /** Existing host directory used as the child process working directory. */
   readonly cwd: string
+
+  /** Environment entries overlaid on `process.env`; `PWD` is set to `cwd`. */
   readonly env?: Readonly<Record<string, string>>
+
+  /** Caller-owned signal whose abortion terminates the process tree. */
   readonly signal: AbortSignal
+
+  /**
+   * Optional process lifetime in milliseconds.
+   *
+   * Expiry requests the same repeat-safe tree termination as cancellation.
+   */
   readonly timeoutMs?: number
 }
 
@@ -15,7 +34,9 @@ export interface LocalProcessOptions {
  * Starts one trusted host command with queued output and process-tree cleanup.
  *
  * This is the local process transport used by the ACP engine and Local
- * Sandbox. It does not provide filesystem, access, or network isolation.
+ * Sandbox. It does not provide filesystem, access, or network isolation. The
+ * returned handle exposes Web streams, repeat-safe `kill()`, and a stable
+ * `wait()` result; a pre-aborted signal prevents startup.
  */
 export async function spawnLocalProcess(
   command: string,

--- a/sdk/src/components/context/aml-context.ts
+++ b/sdk/src/components/context/aml-context.ts
@@ -4,17 +4,43 @@ import type { AmlComponent, AmlRenderable } from "../../core/aml-node.js"
  * Props accepted by the lexical Provider owned by one AML Context.
  */
 export interface ContextProviderProps<Value> {
+  /**
+   * Descendant AML values evaluated with this lexical binding.
+   *
+   * Omission creates an empty binding scope.
+   */
   readonly children?: AmlRenderable
+
+  /**
+   * Value reference returned by `useContext` to descendants.
+   *
+   * The prop itself is required even when `Value` intentionally includes
+   * `undefined`. AML captures the reference before descendant evaluation but
+   * does not clone or freeze the supplied value; mutable objects remain shared.
+   */
   readonly value: Value
 }
 
 /**
- * Typed identity for one immutable downward-scoped dependency.
+ * Typed identity for one downward-scoped dependency binding.
  *
  * Context identity is the returned object, not `name`. The name exists only
  * for diagnostics, so separately created contexts never alias accidentally.
  */
 export interface AmlContext<Value> {
+  /**
+   * Non-empty normalized diagnostic name supplied to `createContext`.
+   *
+   * The name does not determine identity and separately created Contexts with
+   * the same name never share values.
+   */
   readonly name: string
+
+  /**
+   * Lexical AML component that binds a required `value` for its descendants.
+   *
+   * Nested Providers shadow outer bindings only for their own subtree. Direct
+   * invocation is invalid; use it as JSX evaluated by `AmlRuntime`.
+   */
   readonly Provider: AmlComponent<ContextProviderProps<Value>>
 }

--- a/sdk/src/components/context/create-context.ts
+++ b/sdk/src/components/context/create-context.ts
@@ -3,6 +3,13 @@ import { ContextRegistry } from "./context-registry.js"
 
 /**
  * Defines one required immutable downward-scoped dependency.
+ *
+ * Reading the returned Context without a matching Provider during an active
+ * component invocation throws an EvaluationError. `name` is diagnostic and
+ * must be a non-empty, already-trimmed string; Context identity is based on the
+ * returned object, not that name.
+ *
+ * @param name Human-readable Context name used in validation errors.
  */
 export function createContext<Value>(name: string): AmlContext<Value>
 
@@ -11,11 +18,18 @@ export function createContext<Value>(name: string): AmlContext<Value>
  *
  * The overload intentionally accepts `undefined`: supplying a second argument
  * is distinct from omitting it and therefore still defines a default.
+ * The nearest Provider still takes precedence over this fallback.
+ *
+ * @param name Human-readable Context name used in validation errors.
+ * @param defaultValue Value returned when no Provider exists in the active scope.
  */
 export function createContext<Value>(name: string, defaultValue: Value): AmlContext<Value>
 
 /**
  * Captures Context identity without reading application data or running AML.
+ *
+ * Call this once at module scope and share the returned definition with its
+ * Provider and every `useContext()` consumer.
  */
 export function createContext<Value>(name: string, ...defaultValue: [] | [Value]): AmlContext<Value> {
   if (typeof name !== "string" || name.length === 0 || name !== name.trim()) {

--- a/sdk/src/components/context/use-context.ts
+++ b/sdk/src/components/context/use-context.ts
@@ -7,6 +7,13 @@ import { ContextRegistry } from "./context-registry.js"
  *
  * This is an ambient dependency lookup, not a reactive hook: it has no setter,
  * subscription, invalidation, or rerender behavior.
+ *
+ * The nearest matching Provider wins; otherwise the Context's explicit default
+ * is returned. Calling outside an active AML function component, after that
+ * component has settled, with an invalid Context object, or without a binding
+ * or default throws an EvaluationError.
+ *
+ * @param context Exact Context definition previously returned by `createContext()`.
  */
 export function useContext<Value>(context: AmlContext<Value>): Value {
   return ComponentEvaluationContext.readContext<Value>(ContextRegistry.fromContext(context))

--- a/sdk/src/components/file/file.tsx
+++ b/sdk/src/components/file/file.tsx
@@ -4,12 +4,29 @@ import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
  * Text file materialized inside the active Workspace.
  */
 export interface FileProps {
+  /**
+   * AML content resolved to the UTF-8 file body.
+   *
+   * The prop is required, though it may resolve to an empty string. The write
+   * contributes no text to the surrounding AML result.
+   */
   readonly children: AmlRenderable
+
+  /**
+   * Portable relative destination beneath the active Workspace materialization.
+   *
+   * The path must identify a file, cannot escape the Workspace root, and cannot
+   * traverse a symlink or replace a directory.
+   */
   readonly path: string
 }
 
 /**
- * Writes resolved child text without adding it to the surrounding prompt.
+ * Atomically writes resolved child text into the active host Workspace.
+ *
+ * Parent directories are created safely and an existing regular file may be
+ * replaced. The component requires an enclosing `Workspace`, is invalid inside
+ * a `Sandbox`, and leaves durable publication to the Workspace save policy.
  */
 export function File(_props: FileProps): never {
   throw new Error("<File> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/follow-up/follow-up.tsx
+++ b/sdk/src/components/follow-up/follow-up.tsx
@@ -4,6 +4,13 @@ import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
  * Authored content for one later input in its containing Agent session.
  */
 export interface FollowUpProps {
+  /**
+   * Content for one later user turn in the containing Agent session.
+   *
+   * AML resolves and trims the content before the session opens. It must become
+   * non-empty text; omission therefore fails evaluation rather than creating an
+   * empty turn.
+   */
   readonly children?: AmlRenderable
 }
 
@@ -11,7 +18,9 @@ export interface FollowUpProps {
  * Stages one static later input in the nearest containing Agent session.
  *
  * AmlRuntime resolves the complete descriptor before the provider session
- * starts; this component never opens or resumes a session itself.
+ * starts; this component never opens or resumes a session itself. Follow-ups
+ * retain authored order, share the Agent's provider, history, and capabilities,
+ * and count toward the runtime's per-Agent turn limit.
  */
 export function FollowUp(_props: FollowUpProps): never {
   throw new Error("<FollowUp> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/loop/loop.tsx
+++ b/sdk/src/components/loop/loop.tsx
@@ -14,7 +14,10 @@ type SelfNormalizingSchema<Schema extends ObjectStateSchema> =
   StandardSchemaV1.InferOutput<Schema> extends StandardSchemaV1.InferInput<Schema> ? Schema : never
 
 /**
- * Recursive read-only view supplied to one Loop render iteration.
+ * Recursively marks arrays and object properties read-only for a Loop snapshot.
+ *
+ * Functions retain their callable type because Loop state itself must remain
+ * stable JSON and therefore cannot contain functions.
  */
 export type DeepReadonly<Value> = Value extends (...args: never[]) => unknown
   ? Value
@@ -32,7 +35,10 @@ export type DeepReadonly<Value> = Value extends (...args: never[]) => unknown
  * Immutable snapshot and one-based iteration number supplied by `<Loop>`.
  */
 export interface LoopRenderContext<State extends Record<string, unknown>> {
+  /** One-based iteration number. The first call to `render` receives `1`. */
   readonly iteration: number
+
+  /** Deeply frozen, schema-normalized state committed before this iteration. */
   readonly state: DeepReadonly<State>
 }
 
@@ -44,9 +50,35 @@ export interface LoopRenderContext<State extends Record<string, unknown>> {
  * Output must remain valid input because every staged snapshot is revalidated.
  */
 export interface LoopProps<Schema extends ObjectStateSchema> {
+  /**
+   * Authored state validated and normalized before the first iteration.
+   *
+   * It must resolve through `schema` to a stable JSON object. Its normalized
+   * output becomes the first immutable render snapshot.
+   */
   readonly initial: StandardSchemaV1.InferInput<Schema>
+
+  /**
+   * Non-empty normalized label used in the state Tool and diagnostics.
+   *
+   * Defaults to `"Loop"`.
+   */
   readonly name?: string
+
+  /**
+   * Produces exactly one outer `Agent` for each immutable state snapshot.
+   *
+   * Function components and Context providers may transparently wrap the Agent.
+   * The iteration repeats only when that Agent stages a changed state.
+   */
   readonly render: (context: LoopRenderContext<StandardSchemaV1.InferOutput<Schema>>) => AmlRenderable
+
+  /**
+   * Standard Schema that validates every initial, staged, and repeated snapshot.
+   *
+   * Its output must be a stable JSON object that remains valid as the schema's
+   * input, allowing AML to revalidate each atomic state patch.
+   */
   readonly schema: SelfNormalizingSchema<Schema>
 }
 
@@ -55,6 +87,9 @@ export interface LoopProps<Schema extends ObjectStateSchema> {
  *
  * AmlRuntime owns this primitive because its state Tool must expire at the
  * Agent-session boundary and commits must occur only after that session ends.
+ * The last Agent output is returned when an iteration stages no state change.
+ *
+ * @experimental Loop is exported for evaluation and is not yet a stable API.
  */
 export function Loop<Schema extends ObjectStateSchema>(_props: LoopProps<Schema>): never {
   throw new Error("<Loop> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/mcp/aml-mcp-server.ts
+++ b/sdk/src/components/mcp/aml-mcp-server.ts
@@ -8,10 +8,30 @@ interface AmlMcpServerGlobal {
  * Portable local-process MCP transport owned at runtime by an Agent provider.
  */
 export interface AmlMcpStdioTransport {
+  /** Literal process arguments; omitted means no arguments. */
   readonly args?: readonly string[]
+
+  /** Non-empty normalized executable name or path. */
   readonly command: string
+
+  /**
+   * Provider-environment working directory for the server process.
+   *
+   * Omission leaves cwd selection to the Agent provider. The provider also
+   * determines whether this path belongs to the host, Sandbox, or another
+   * execution environment.
+   */
   readonly cwd?: string
+
+  /**
+   * String environment entries supplied to the server process.
+   *
+   * Omission adds no definition-specific entries. Treat values as potentially
+   * secret provider configuration.
+   */
   readonly env?: Readonly<Record<string, string>>
+
+  /** Transport discriminant for a provider-owned local process. */
   readonly type: "stdio"
 }
 
@@ -19,8 +39,18 @@ export interface AmlMcpStdioTransport {
  * Portable remote Streamable HTTP transport owned by an Agent provider.
  */
 export interface AmlMcpStreamableHttpTransport {
+  /**
+   * Request headers snapshotted when the server is defined.
+   *
+   * Omission sends no definition-specific headers. Values may contain secrets
+   * and are passed to the selected Agent provider.
+   */
   readonly headers?: Readonly<Record<string, string>>
+
+  /** Transport discriminant for a remote Streamable HTTP endpoint. */
   readonly type: "streamable-http"
+
+  /** Normalized absolute `http:` or `https:` endpoint URL. */
   readonly url: string
 }
 
@@ -37,7 +67,11 @@ export interface AmlMcpServer {
    * Non-enumerable authoring marker; runtime authenticity uses exact identity.
    */
   readonly __amlMcpServer: true
+
+  /** Non-empty normalized capability name used for grants and allowlists. */
   readonly name: string
+
+  /** Immutable normalized transport owned at runtime by the Agent provider. */
   readonly transport: AmlMcpTransport
 }
 
@@ -46,11 +80,17 @@ export interface AmlMcpServer {
  */
 export type AgentMcpServer =
   | {
+      /** Exact immutable server descriptor created by `defineMcpServer`. */
       readonly definition: AmlMcpServer
+
+      /** Discriminant for an explicitly configured transport. */
       readonly kind: "configured"
     }
   | {
+      /** Discriminant for a server configured natively by the Agent provider. */
       readonly kind: "named"
+
+      /** Non-empty normalized provider-native MCP server name. */
       readonly name: string
     }
 

--- a/sdk/src/components/mcp/define-mcp-server.ts
+++ b/sdk/src/components/mcp/define-mcp-server.ts
@@ -9,10 +9,19 @@ import {
  * Local-process transport accepted by `defineMcpServer()`.
  */
 export interface DefineMcpStdioTransport {
+  /** Literal process arguments copied at definition time; omitted means none. */
   readonly args?: readonly string[]
+
+  /** Non-empty normalized executable name or path. */
   readonly command: string
+
+  /** Optional non-empty normalized cwd interpreted by the Agent provider. */
   readonly cwd?: string
+
+  /** Optional string environment record copied at definition time. */
   readonly env?: Readonly<Record<string, string>>
+
+  /** Selects a provider-owned process transport. */
   readonly type: "stdio"
 }
 
@@ -20,8 +29,13 @@ export interface DefineMcpStdioTransport {
  * Streamable HTTP input accepts URL objects before normalizing to text.
  */
 export interface DefineMcpStreamableHttpTransport {
+  /** Optional string request headers copied at definition time. */
   readonly headers?: Readonly<Record<string, string>>
+
+  /** Selects a remote Streamable HTTP transport. */
   readonly type: "streamable-http"
+
+  /** Absolute HTTP(S) endpoint; `URL` inputs are normalized to `url.href`. */
   readonly url: string | URL
 }
 
@@ -29,12 +43,20 @@ export interface DefineMcpStreamableHttpTransport {
  * Complete side-effect-free MCP definition input.
  */
 export interface DefineMcpServerOptions {
+  /** Non-empty normalized capability name used by `Mcp` and runtime allowlists. */
   readonly name: string
+
+  /** Stdio or Streamable HTTP connection settings to snapshot and normalize. */
   readonly transport: DefineMcpStdioTransport | DefineMcpStreamableHttpTransport
 }
 
 /**
  * Defines one immutable portable MCP server without connecting to it.
+ *
+ * AML captures each input once, validates and copies authority-bearing arrays
+ * and records, normalizes HTTP URLs, and registers the exact returned identity.
+ * Process startup, connection, authentication, discovery, and grants happen
+ * later at the selected Agent provider and `Mcp` boundaries.
  */
 export function defineMcpServer(options: DefineMcpServerOptions): Readonly<AmlMcpServer> {
   if (typeof options !== "object" || options === null) {

--- a/sdk/src/components/mcp/mcp.tsx
+++ b/sdk/src/components/mcp/mcp.tsx
@@ -6,16 +6,37 @@ import type { AmlMcpServer } from "./aml-mcp-server.js"
  */
 export type McpProps =
   | {
+      /**
+       * Non-empty normalized name of a provider-native MCP server.
+       *
+       * The selected Agent provider must recognize and expose this name. Names
+       * must be unique within one Agent and may be restricted by the runtime's
+       * `allowedMcpServers` allowlist.
+       */
       readonly name: string
+
+      /** Must be omitted when selecting a provider-native server by `name`. */
       readonly use?: never
     }
   | {
+      /** Must be omitted when attaching an explicit server through `use`. */
       readonly name?: never
+
+      /**
+       * Exact stdio or Streamable HTTP definition returned by `defineMcpServer`.
+       *
+       * The Agent provider owns connection and session lifecycle. Transport
+       * support and the location of stdio execution are provider-specific.
+       */
       readonly use: AmlMcpServer
     }
 
 /**
- * Declares one MCP capability for its nearest containing Agent.
+ * Grants one MCP capability to its nearest containing Agent.
+ *
+ * Choose exactly one of a provider-native `name` or an explicit `use`
+ * definition. The grant is Agent-local, accepts no children, and does not
+ * itself connect to or run the server.
  */
 export function Mcp(_props: McpProps): never {
   throw new Error("<Mcp> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/parallel/parallel.tsx
+++ b/sdk/src/components/parallel/parallel.tsx
@@ -4,19 +4,30 @@ import { EvaluationError } from "../../core/evaluation-error.js"
 
 /** Independent AML branches evaluated concurrently in authored order. */
 export interface ParallelProps {
+  /**
+   * Independent AML branches to evaluate concurrently.
+   *
+   * Nested child arrays are flattened, nullish and boolean children are ignored,
+   * and each Fragment remains one branch. Omission produces no branches.
+   */
   readonly children?: AmlRenderable
 }
 
 /** Identifies one failed Parallel branch without hiding its original cause. */
 export interface ParallelFailure {
+  /** Zero-based position of the rejected branch after child-array flattening. */
   readonly branchIndex: number
+
+  /** Original value with which the branch rejected. */
   readonly cause: unknown
 }
 
 /** Reports every failed Parallel branch in authored order. */
 export class ParallelError extends Error {
+  /** Every rejected branch, ordered by authored branch position. */
   readonly failures: readonly ParallelFailure[]
 
+  /** Creates an aggregate branch error without replacing the original causes. */
   constructor(failures: readonly ParallelFailure[]) {
     const branches = failures.map(failure => failure.branchIndex + 1).join(", ")
     super(failures.length === 1 ? `<Parallel> branch ${branches} failed` : `<Parallel> branches ${branches} failed`)
@@ -28,6 +39,10 @@ export class ParallelError extends Error {
 /**
  * Evaluates each flattened child concurrently and renders successful outputs
  * in authored order after every branch has settled.
+ *
+ * Completion order never changes the result order. The component waits for all
+ * branch cleanup and then throws one `ParallelError` when any branch failed;
+ * successful side effects are not rolled back.
  */
 export async function Parallel({ children }: ParallelProps): Promise<readonly string[]> {
   const branches = flattenBranches(children)

--- a/sdk/src/components/sandbox/abstract-sandbox-provider.ts
+++ b/sdk/src/components/sandbox/abstract-sandbox-provider.ts
@@ -14,14 +14,20 @@ export abstract class AbstractSandboxProvider<
   Handle,
   Resource,
 > implements SandboxProvider<Handle> {
+  /** Stable non-empty normalized provider identifier used in diagnostics. */
   readonly name: Name
 
+  /** Creates a staged provider base while retaining the literal name type. */
   protected constructor(name: Name) {
     this.name = name
   }
 
   /**
    * Provisions, initializes, and returns one immutable Sandbox lease.
+   *
+   * A pre-aborted request starts no work. Any failure after `provision` resolves
+   * is compensated through `cleanupProvisioned`; the returned `release` caches
+   * the complete `releaseResource` operation.
    */
   async acquire(request: SandboxAcquireRequest): Promise<SandboxLease<Handle>> {
     request.signal.throwIfAborted()
@@ -65,6 +71,9 @@ export abstract class AbstractSandboxProvider<
 
   /**
    * Builds the narrow runtime over one successfully provisioned environment.
+   *
+   * The runtime must enforce the request's effective access, root, cwd, literal
+   * argument semantics, cancellation, output bounds, and process cleanup.
    */
   protected abstract createRuntime(
     provisioned: Readonly<ProvisionedSandbox<Handle, Resource>>,
@@ -73,6 +82,9 @@ export abstract class AbstractSandboxProvider<
 
   /**
    * Performs post-provision setup before the lease becomes visible.
+   *
+   * The default performs no setup. Overrides may hydrate a Workspace or run
+   * trusted configuration and should honor `request.signal`.
    */
   protected async initialize(
     _provisioned: Readonly<ProvisionedSandbox<Handle, Resource>>,
@@ -82,6 +94,9 @@ export abstract class AbstractSandboxProvider<
 
   /**
    * Compensates failed initialization without assuming successful evaluation.
+   *
+   * The default delegates to `releaseResource`; override only when a partially
+   * initialized resource requires a different cleanup path.
    */
   protected async cleanupProvisioned(
     provisioned: Readonly<ProvisionedSandbox<Handle, Resource>>,
@@ -92,6 +107,10 @@ export abstract class AbstractSandboxProvider<
 
   /**
    * Reconciles and releases one successfully exposed provider resource.
+   *
+   * Implementations must release evaluation-owned executions and authority even
+   * when reconciliation fails. Shared durable infrastructure need not be
+   * destroyed, but this evaluation's lease must end.
    */
   protected abstract releaseResource(
     provisioned: Readonly<ProvisionedSandbox<Handle, Resource>>,

--- a/sdk/src/components/sandbox/define-sandbox-provider.ts
+++ b/sdk/src/components/sandbox/define-sandbox-provider.ts
@@ -4,7 +4,9 @@ import { validateSandboxProvider } from "./validate-sandbox-provider.js"
 /**
  * Finalizes one Sandbox implementation as an immutable AML adapter.
  *
- * This definition step performs no acquisition or provider-specific setup.
+ * This definition step validates the provider name and `acquire` function, then
+ * shallow-freezes the original object. It performs no acquisition, proves no
+ * isolation property, and does not freeze provider-owned nested state.
  */
 export function defineSandboxProvider<const Provider extends SandboxProvider>(
   implementation: Provider

--- a/sdk/src/components/sandbox/provisioned-sandbox.ts
+++ b/sdk/src/components/sandbox/provisioned-sandbox.ts
@@ -5,7 +5,12 @@
  * therefore compensate every later initialization failure.
  */
 export interface ProvisionedSandbox<Handle, Resource> {
+  /** Opaque descendant-facing identity exposed through the Sandbox lease. */
   readonly handle: Handle
+
+  /** Stable non-empty lease identifier used for diagnostics and cleanup. */
   readonly id: string
+
+  /** Provider-private resource needed to initialize, reconcile, and release. */
   readonly resource: Resource
 }

--- a/sdk/src/components/sandbox/sandbox-command.ts
+++ b/sdk/src/components/sandbox/sandbox-command.ts
@@ -7,11 +7,22 @@ import type { SandboxExecOptions } from "./sandbox-runtime.js"
  * Captured and validated provider-neutral Sandbox command.
  */
 export class SandboxCommand {
+  /** Frozen literal argument list; empty when the caller supplied none. */
   readonly args: readonly string[]
+
+  /** Non-empty executable string captured without shell parsing. */
   readonly command: string
+
+  /** Normalized logical cwd constrained beneath the acquired Sandbox root. */
   readonly cwd: string
+
+  /** Frozen command-specific environment entries; empty when omitted. */
   readonly env: Readonly<Record<string, string>>
+
+  /** Effective command signal, defaulting to the acquisition signal. */
   readonly signal: AbortSignal
+
+  /** Positive timer-safe command limit in milliseconds, when supplied. */
   readonly timeoutMs: number | undefined
 
   private constructor(input: {
@@ -33,6 +44,11 @@ export class SandboxCommand {
 
   /**
    * Captures one runtime call without trusting mutable caller-owned values.
+   *
+   * Arguments default to `[]` and options to `{}`. The method snapshots arrays
+   * and environment records, validates portable cwd confinement and timer range,
+   * inherits missing cwd and signal values from acquisition, and rejects a
+   * pre-aborted effective signal.
    */
   static from(
     request: SandboxAcquireRequest,

--- a/sdk/src/components/sandbox/sandbox-provider.ts
+++ b/sdk/src/components/sandbox/sandbox-provider.ts
@@ -10,11 +10,26 @@ export type SandboxAccess = "read-only" | "read-write"
  * Validated policy supplied when AML acquires an outermost Sandbox.
  */
 export interface SandboxAcquireRequest {
+  /** Effective filesystem authority that the provider must enforce. */
   readonly access: SandboxAccess
+
+  /** Normalized logical default cwd at or beneath `root`. */
   readonly cwd: string
+
+  /** Unique identity of the AML evaluation acquiring this lease. */
   readonly evaluationId: string
+
+  /** Normalized logical filesystem root visible to Sandbox descendants. */
   readonly root: string
+
+  /** Evaluation signal covering acquisition and all lease-owned work. */
   readonly signal: AbortSignal
+
+  /**
+   * Active Workspace materialization to attach to the environment, when present.
+   *
+   * The reference exposes no save, release, or provider acquisition authority.
+   */
   readonly workspace?: Readonly<WorkspaceMaterializationReference>
 }
 
@@ -25,12 +40,21 @@ export interface SandboxAcquireRequest {
  * providers without assuming a command, process, or filesystem API.
  */
 export interface SandboxLease<Handle = unknown> {
+  /** Opaque provider-defined value available to compatible Agent adapters. */
   readonly handle: Handle
+
+  /** Stable non-empty identity for this acquired lease. */
   readonly id: string
+
+  /** Provider-neutral command runtime enforcing the acquired effective policy. */
   readonly runtime: SandboxRuntime
 
   /**
    * Releases every resource owned by this lease.
+   *
+   * Calls must be safe to repeat. Release should terminate evaluation-owned
+   * executions and relinquish authority even when reconciliation or deletion
+   * encounters an error.
    */
   release(): Promise<void>
 }
@@ -39,10 +63,14 @@ export interface SandboxLease<Handle = unknown> {
  * Acquires provider-owned ephemeral execution environments.
  */
 export interface SandboxProvider<Handle = unknown> {
+  /** Non-empty normalized provider identifier used in errors and traces. */
   readonly name: string
 
   /**
    * Acquires one environment for an already validated portable policy.
+   *
+   * A pre-aborted signal must start no work. Once a lease is returned, AML calls
+   * its release boundary after success, failure, or cancellation.
    */
   acquire(request: SandboxAcquireRequest): Promise<SandboxLease<Handle>>
 }
@@ -51,8 +79,13 @@ export interface SandboxProvider<Handle = unknown> {
  * Non-authoritative lease data visible to compatible descendants.
  */
 export interface SandboxLeaseReference<Handle = unknown> {
+  /** Opaque provider-defined handle without release authority. */
   readonly handle: Handle
+
+  /** Stable identity of the acquired outer lease. */
   readonly id: string
+
+  /** Read-only provider-neutral execution runtime for the effective scope. */
   readonly runtime: Readonly<SandboxRuntime>
 }
 
@@ -60,6 +93,7 @@ export interface SandboxLeaseReference<Handle = unknown> {
  * Stable provider identity visible without exposing acquisition authority.
  */
 export interface SandboxProviderReference {
+  /** Stable provider name without access to its acquisition method. */
   readonly name: string
 }
 
@@ -67,10 +101,21 @@ export interface SandboxProviderReference {
  * Effective Sandbox policy and opaque lease inherited by an Agent.
  */
 export interface SandboxSession<Handle = unknown> {
+  /** Effective filesystem authority after all Sandbox nesting restrictions. */
   readonly access: SandboxAccess
+
+  /** Effective normalized logical cwd for descendants. */
   readonly cwd: string
+
+  /** Non-authoritative reference to the one acquired outer lease. */
   readonly lease: SandboxLeaseReference<Handle>
+
+  /** Whether this session is a restricted view of an existing outer lease. */
   readonly nested: boolean
+
+  /** Stable identity of the provider that acquired the outer lease. */
   readonly provider: SandboxProviderReference
+
+  /** Effective normalized logical root after nesting restrictions. */
   readonly root: string
 }

--- a/sdk/src/components/sandbox/sandbox-runtime.ts
+++ b/sdk/src/components/sandbox/sandbox-runtime.ts
@@ -7,9 +7,26 @@ import type { SandboxAccess, SandboxSession } from "./sandbox-provider.js"
  * to the corresponding host, container, or remote path.
  */
 export interface SandboxExecOptions {
+  /**
+   * Normalized logical working directory for this command.
+   *
+   * Omission uses the runtime cwd. A supplied value must remain beneath the
+   * acquired root.
+   */
   readonly cwd?: string
+
+  /** Command-specific string environment entries; omission supplies none. */
   readonly env?: Readonly<Record<string, string>>
+
+  /**
+   * Command-specific cancellation signal.
+   *
+   * Omission uses the Sandbox acquisition signal. Providers must propagate the
+   * effective signal to process startup, execution, and cleanup.
+   */
   readonly signal?: AbortSignal
+
+  /** Optional positive timer-safe execution limit in milliseconds. */
   readonly timeoutMs?: number
 }
 
@@ -17,8 +34,13 @@ export interface SandboxExecOptions {
  * Completed output from one bounded Sandbox command.
  */
 export interface SandboxExecResult {
+  /** Process exit status; non-zero values are results rather than thrown errors. */
   readonly exitCode: number
+
+  /** Bounded UTF-8 standard error captured after the process exits. */
   readonly stderr: string
+
+  /** Bounded UTF-8 standard output captured after the process exits. */
   readonly stdout: string
 }
 
@@ -26,6 +48,7 @@ export interface SandboxExecResult {
  * Immutable completion state for one spawned Sandbox process.
  */
 export interface SandboxProcessExit {
+  /** Process exit status captured once for every `wait()` caller. */
   readonly exitCode: number
 }
 
@@ -36,18 +59,35 @@ export interface SandboxProcessExit {
  * provider-specific PID or stdin API on callers.
  */
 export interface SandboxProcess {
+  /**
+   * Opaque provider-defined execution identity used only for diagnostics.
+   *
+   * Consumers must not assume it is an operating-system PID.
+   */
   readonly id: string
+
+  /** Writable byte stream connected to process standard input. */
   readonly stdin: WritableStream<Uint8Array>
+
+  /** Readable byte stream connected to process standard error. */
   readonly stderr: ReadableStream<Uint8Array>
+
+  /** Readable byte stream connected to process standard output. */
   readonly stdout: ReadableStream<Uint8Array>
 
   /**
    * Terminates the process and its descendants. Repeated calls are safe.
+   *
+   * Resolution means the termination request completed; callers use `wait()`
+   * to observe an actual process exit.
    */
   kill(): Promise<void>
 
   /**
    * Waits for completion and returns the same captured result on every call.
+   *
+   * Rejection means completion could not be observed and must not be interpreted
+   * as proof that the process exited.
    */
   wait(): Promise<Readonly<SandboxProcessExit>>
 }
@@ -60,12 +100,21 @@ export interface SandboxProcess {
  * snapshot, or port APIs.
  */
 export interface SandboxRuntime {
+  /** Filesystem authority this runtime actually enforces. */
   readonly access: SandboxAccess
+
+  /** Normalized logical default working directory for commands. */
   readonly cwd: string
+
+  /** Normalized logical root that command cwd values cannot escape. */
   readonly root: string
 
   /**
    * Executes one executable with literal arguments inside the Sandbox.
+   *
+   * `args` defaults to an empty array and `options` to inherited runtime values.
+   * The promise resolves for ordinary non-zero process exits and rejects for
+   * transport, cancellation, timeout, or output-bound failures.
    */
   exec(
     command: string,
@@ -75,6 +124,10 @@ export interface SandboxRuntime {
 
   /**
    * Starts one executable with literal arguments and streaming stdio.
+   *
+   * `args` defaults to an empty array and `options` to inherited runtime values.
+   * The returned process must support repeat-safe termination and completion
+   * observation for cleanup-sensitive Agent protocols.
    */
   spawn(
     command: string,
@@ -87,7 +140,9 @@ export interface SandboxRuntime {
  * Checks whether a lease runtime enforces an Agent's effective Sandbox view.
  *
  * The first runtime version supports Agent-local cwd changes but cannot
- * manufacture nested root or access narrowing after acquisition.
+ * manufacture nested root or access narrowing after acquisition. The check is
+ * structural: it requires `exec`, `spawn`, and exact root/access equality, but
+ * it does not prove deployment isolation, credentials, or executable presence.
  */
 export function supportsSandboxRuntime(session: SandboxSession): boolean {
   try {

--- a/sdk/src/components/sandbox/sandbox.tsx
+++ b/sdk/src/components/sandbox/sandbox.tsx
@@ -5,17 +5,58 @@ import type { SandboxAccess, SandboxProvider } from "./sandbox-provider.js"
  * Portable policy and provider selection for one ephemeral execution scope.
  */
 export interface SandboxProps {
+  /**
+   * Portable filesystem authority requested for this scope.
+   *
+   * An outer Sandbox defaults to `"read-only"`; a nested Sandbox inherits its
+   * parent when omitted. Nested scopes may narrow read-write to read-only but
+   * cannot widen read-only access.
+   */
   readonly access?: SandboxAccess
+
+  /**
+   * AML values evaluated while the effective Sandbox session is active.
+   *
+   * Omission evaluates an empty scope and still acquires and releases an outer
+   * lease.
+   */
   readonly children?: AmlRenderable
+
+  /**
+   * Portable logical working directory exposed to descendants.
+   *
+   * For an outer Sandbox, an explicit `root` is also the default cwd. When both
+   * props are omitted, cwd defaults to the enclosing Workspace cwd and then
+   * `"."`. In a nested Sandbox it resolves within the nested root and otherwise
+   * inherits the parent cwd.
+   */
   readonly cwd?: string
+
+  /**
+   * Provider used to acquire an outer Sandbox lease.
+   *
+   * When omitted, AML uses `AmlRuntimeOptions.sandboxProvider`. Nested Sandboxes
+   * always reuse the parent lease and therefore cannot set this prop.
+   */
   readonly provider?: SandboxProvider
+
+  /**
+   * Portable logical root visible to this scope and its descendants.
+   *
+   * An outer Sandbox defaults to `"."`. A nested value resolves beneath and
+   * narrows the parent root; it cannot escape that root.
+   */
   readonly root?: string
 }
 
 /**
  * Scopes one provider-owned execution lease to its descendants.
  *
- * Nested Sandboxes restrict the active lease; they never acquire another one.
+ * The outermost Sandbox acquires and releases the provider resource even when a
+ * descendant fails. Nested Sandboxes create restrictive logical views of the
+ * active lease and never acquire another resource. Script execution and
+ * compatible Agents receive the effective session; native permission flags
+ * cannot widen its policy.
  */
 export function Sandbox(_props: SandboxProps): never {
   throw new Error("<Sandbox> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/script/script.tsx
+++ b/sdk/src/components/script/script.tsx
@@ -1,12 +1,31 @@
 import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
 
+/**
+ * Explicit interpreter available to the source form of `Script`.
+ *
+ * `"sh"` and `"bash"` receive source through `-c`; `"node"` evaluates it as an
+ * ES module. AML does not choose an interpreter implicitly.
+ */
 export type ScriptShell = "bash" | "node" | "sh"
 
 /**
  * Options shared by both Script execution forms.
  */
 interface SharedScriptProps {
+  /**
+   * Portable relative working directory for the process.
+   *
+   * On the host it resolves from `AmlRuntimeOptions.cwd`; in a Sandbox it
+   * resolves from the effective Sandbox root. Omission uses the active cwd.
+   */
   readonly cwd?: string
+
+  /**
+   * Positive safe-integer execution limit in milliseconds.
+   *
+   * Omission applies no Script-local timeout. Evaluation cancellation remains
+   * active in both host and Sandbox execution.
+   */
   readonly timeoutMs?: number
 }
 
@@ -15,20 +34,51 @@ interface SharedScriptProps {
  */
 export type ScriptProps =
   | (SharedScriptProps & {
+      /**
+       * Literal arguments passed directly to `command` without shell joining.
+       *
+       * Defaults to an empty array.
+       */
       readonly args?: readonly string[]
+
+      /** Must be omitted in literal-command form. */
       readonly children?: never
+
+      /**
+       * Non-empty normalized executable name or path invoked directly.
+       *
+       * AML does not parse shell syntax or interpolate `args` into this value.
+       */
       readonly command: string
+
+      /** Must be omitted in literal-command form. */
       readonly shell?: never
     })
   | (SharedScriptProps & {
+      /** Must be omitted in interpreted-source form. */
       readonly args?: never
+
+      /**
+       * AML content resolved to non-empty source for the selected `shell`.
+       *
+       * Nested Agents or components finish before the source process starts.
+       */
       readonly children: AmlRenderable
+
+      /** Must be omitted in interpreted-source form. */
       readonly command?: never
+
+      /** Explicit interpreter used to execute the resolved child source. */
       readonly shell: ScriptShell
     })
 
 /**
  * Executes resolved AML text or one literal command on the host or in the active Sandbox.
+ *
+ * Outside a Sandbox this is trusted, unconfined host execution. Inside a
+ * Sandbox the active provider runtime is mandatory and AML never falls back to
+ * the host. Successful stdout becomes AML text; a non-zero exit rejects with
+ * stderr detail when available.
  */
 export function Script(_props: ScriptProps): never {
   throw new Error("<Script> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/skill/skill.tsx
+++ b/sdk/src/components/skill/skill.tsx
@@ -4,14 +4,46 @@ import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
  * Local and inline instruction content plus optional model-facing labels.
  */
 export interface SkillProps {
+  /**
+   * Inline AML instruction content.
+   *
+   * When `src` is also present, file content comes first, followed by a newline
+   * and the resolved children. At least one of `children` or `src` is required,
+   * and their combined content must resolve to non-empty text.
+   */
   readonly children?: AmlRenderable
+
+  /**
+   * Optional non-empty normalized model-facing description.
+   *
+   * When supplied, AML prepends it as `Description: …` before the instruction
+   * content. Omission adds no description label.
+   */
   readonly description?: string
+
+  /**
+   * Optional non-empty normalized model-facing Skill name.
+   *
+   * When supplied, AML prepends it as `Skill: …` before the instruction content.
+   * Omission adds no name label.
+   */
   readonly name?: string
+
+  /**
+   * Local UTF-8 instruction file read at evaluation time.
+   *
+   * Relative paths resolve from `AmlRuntimeOptions.cwd`, not from an active
+   * Workspace or Sandbox. Omission uses inline children only.
+   */
   readonly src?: string
 }
 
 /**
- * Contributes resolved instruction text at its authored position.
+ * Contributes reusable local or inline instruction text at its authored position.
+ *
+ * This is ordinary prompt text rather than an installed coding-agent capability.
+ * AML reads `src` after child evaluation, does not cache it, and preserves the
+ * component's authored placement inside an Agent prompt or `System` block.
  */
 export function Skill(_props: SkillProps): never {
   throw new Error("<Skill> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/system/system.tsx
+++ b/sdk/src/components/system/system.tsx
@@ -4,11 +4,20 @@ import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
  * Children whose resolved text becomes part of the nearest Agent system prompt.
  */
 export interface SystemProps {
+  /**
+   * AML content resolved into system text for the nearest containing Agent.
+   *
+   * Omission contributes no fragment. Multiple `System` components preserve
+   * authored order after runtime-wide and Agent-level fixed system text.
+   */
   readonly children?: AmlRenderable
 }
 
 /**
  * Routes resolved child text into the nearest Agent system prompt.
+ *
+ * The component opens no session and changes only the message channel; provider,
+ * Sandbox, Tool, and MCP scope continue to belong to the containing Agent.
  */
 export function System(_props: SystemProps): never {
   throw new Error("<System> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/tool/agent-tool.ts
+++ b/sdk/src/components/tool/agent-tool.ts
@@ -22,7 +22,10 @@ export type AmlToolSchema<Input = unknown, Output = Input> = StandardSchemaV1<In
  * Invocation-scoped information supplied to a JavaScript Tool.
  */
 export interface AgentToolExecutionContext {
+  /** Evaluation signal that application Tool work must honor cooperatively. */
   readonly signal: AbortSignal
+
+  /** Trace identity of the Tool call inside its containing Agent turn. */
   readonly trace: AmlTraceIdentity
 }
 
@@ -30,14 +33,25 @@ export interface AgentToolExecutionContext {
  * Provider-facing JavaScript capability after AML has captured its contract.
  */
 export interface AgentJavaScriptTool {
+  /** Non-empty model-facing explanation of what the capability does. */
   readonly description: string
 
   /**
    * Executes the capability with provider-supplied input and evaluation context.
+   *
+   * AML validates input before application code runs and returns a stable
+   * JSON-compatible snapshot. Providers and conformance tests use this low-level
+   * method; application components normally call the `AmlTool` function.
    */
   execute(input: unknown, context: AgentToolExecutionContext): Promise<AmlJsonValue>
+
+  /** Immutable JSON Schema advertised to the model for Tool-call arguments. */
   readonly inputSchema: Readonly<Record<string, unknown>>
+
+  /** Provider-facing capability discriminant. */
   readonly kind: "javascript"
+
+  /** Non-empty normalized model-facing Tool name. */
   readonly name: string
 }
 
@@ -56,9 +70,19 @@ export type AgentTool = AgentJavaScriptTool
 export interface AmlTool<Input = never, Output = AmlJsonValue> extends AgentJavaScriptTool {
   /**
    * Invokes this Tool through the active AML function component.
+   *
+   * Calls inherit the component's cancellation, trace, and resource lifetime.
+   * Calling outside an active component fails; calling does not grant the Tool
+   * to any Agent.
    */
   (input: Input): Promise<Output>
 
+  /**
+   * Non-enumerable authoring marker present on `defineTool` results.
+   *
+   * Runtime authenticity uses exact registered identity rather than trusting
+   * this structurally reproducible field.
+   */
   readonly __amlTool: true
 }
 

--- a/sdk/src/components/tool/define-tool.ts
+++ b/sdk/src/components/tool/define-tool.ts
@@ -9,11 +9,23 @@ import { StandardSchemaAdapter, type SchemaValidation } from "./standard-schema-
 import { ToolInputError } from "./tool-input-error.js"
 import { ToolOutputError } from "./tool-output-error.js"
 
+/** Value returned synchronously or through any Promise-compatible implementation. */
 type MaybePromise<Value> = PromiseLike<Value> | Value
 
+/** Fields shared by Tool definitions with and without an output schema. */
 interface DefineToolBase<InputSchema extends AmlToolSchema> {
+  /** Non-empty normalized model-facing description of the Tool operation. */
   readonly description: string
+
+  /**
+   * Standard Schema validator and Standard JSON Schema declaration for input.
+   *
+   * AML snapshots its JSON Schema at definition time and validates every model-
+   * or application-supplied value before calling `execute`.
+   */
   readonly input: InputSchema
+
+  /** Non-empty normalized Tool name used in Agent grants and allowlists. */
   readonly name: string
 }
 
@@ -26,17 +38,33 @@ export type DefineToolOptions<
 > = DefineToolBase<InputSchema> &
   (OutputSchema extends StandardSchemaV1
     ? {
+        /**
+         * Application operation invoked after input validation.
+         *
+         * It receives normalized input plus cancellation and trace context. Its
+         * return value is validated by `output`, then snapshotted as stable JSON.
+         */
         readonly execute: (
           input: StandardSchemaV1.InferOutput<InputSchema>,
           context: AgentToolExecutionContext
         ) => MaybePromise<StandardSchemaV1.InferInput<OutputSchema>>
+
+        /** Standard Schema that validates and may transform `execute` output. */
         readonly output: OutputSchema
       }
     : {
+        /**
+         * Application operation invoked after input validation.
+         *
+         * Without an output schema it must return a JSON-compatible value. AML
+         * snapshots that value before it crosses the provider boundary.
+         */
         readonly execute: (
           input: StandardSchemaV1.InferOutput<InputSchema>,
           context: AgentToolExecutionContext
         ) => MaybePromise<AmlJsonValue>
+
+        /** Omit to use AML's stable JSON boundary without output transformation. */
         readonly output?: undefined
       })
 
@@ -44,7 +72,9 @@ export type DefineToolOptions<
  * Defines one immutable, schema-validated callable JavaScript Tool.
  *
  * Calling the result invokes it through the active AML function component.
- * Its execute method retains the explicit low-level provider and test API.
+ * Its execute method retains the explicit low-level provider and test API. AML
+ * validates and snapshots the definition immediately, then freezes the callable
+ * exact identity; defining a Tool does not grant it to an Agent or run it.
  */
 export function defineTool<
   InputSchema extends AmlToolSchema,

--- a/sdk/src/components/tool/tool-input-error.ts
+++ b/sdk/src/components/tool/tool-input-error.ts
@@ -1,5 +1,9 @@
 /**
  * Reports model-supplied Tool input rejected before application code ran.
+ *
+ * AML throws this when input is neither valid directly nor as JSON, when the
+ * input schema itself fails, or when schema validation rejects the value. The
+ * original parse or validation detail is retained as `cause` where available.
  */
 export class ToolInputError extends Error {
   /**

--- a/sdk/src/components/tool/tool-output-error.ts
+++ b/sdk/src/components/tool/tool-output-error.ts
@@ -1,5 +1,10 @@
 /**
  * Reports a JavaScript Tool result that cannot cross the provider boundary.
+ *
+ * AML throws this when output validation fails or the result cannot be captured
+ * as JSON-compatible data. Application exceptions thrown by the Tool callback
+ * itself are not relabeled as this error. Validation detail is retained as
+ * `cause` where available.
  */
 export class ToolOutputError extends Error {
   /**

--- a/sdk/src/components/tool/tool.tsx
+++ b/sdk/src/components/tool/tool.tsx
@@ -3,11 +3,22 @@ import type { AmlTool } from "./agent-tool.js"
 
 /** Grants one JavaScript Tool created by defineTool(). */
 export interface ToolProps {
+  /**
+   * Exact callable Tool identity returned by `defineTool`.
+   *
+   * Structurally similar functions or objects are rejected. The Tool name must
+   * be unique in the containing Agent and may be restricted by the runtime's
+   * `allowedTools` allowlist.
+   */
   readonly use: AmlTool<never, unknown>
 }
 
 /**
  * Grants one application-defined JavaScript capability to its containing Agent.
+ *
+ * The callback executes in the AML application process, not in an active
+ * Sandbox. AML validates model input, snapshots JSON-compatible output, passes
+ * cancellation and trace context, and keeps the grant local to this Agent.
  */
 export function Tool(_props: ToolProps): never {
   throw new Error("<Tool> can only be evaluated by AmlRuntime")

--- a/sdk/src/components/workspace/define-workspace-provider.ts
+++ b/sdk/src/components/workspace/define-workspace-provider.ts
@@ -2,7 +2,11 @@ import type { WorkspaceProvider } from "./workspace-provider.js"
 import { validateWorkspaceProvider } from "./validate-workspace-provider.js"
 
 /**
- * Validates and freezes one structurally implementable Workspace provider.
+ * Validates and shallow-freezes one structurally implementable Workspace provider.
+ *
+ * The definition step checks the normalized provider name and `acquire` method
+ * without materializing data or proving persistence, locking, or cleanup. Nested
+ * provider-owned state is retained rather than cloned or deeply frozen.
  */
 export function defineWorkspaceProvider<Handle>(
   provider: WorkspaceProvider<Handle>

--- a/sdk/src/components/workspace/workspace-conflict-error.ts
+++ b/sdk/src/components/workspace/workspace-conflict-error.ts
@@ -5,12 +5,21 @@
  * copies without mistaking unrelated provider failures for lock contention.
  */
 export class WorkspaceConflictError extends Error {
+  /** Stable cross-package error code for a healthy active-writer conflict. */
   readonly code = "AML_WORKSPACE_CONFLICT"
+
+  /** Stable JavaScript error name. */
   override readonly name = "WorkspaceConflictError"
+
+  /** Durable Workspace identity whose active writer blocked acquisition. */
   readonly workspaceId: string
 
   /**
    * Identifies the durable Workspace whose active writer rejected acquisition.
+   *
+   * Use this error only for healthy competing writer authority. Stale
+   * publication, storage, authorization, corruption, and cleanup failures retain
+   * their own error identity.
    */
   constructor(workspaceId: string) {
     super(`Workspace "${workspaceId}" already has an active writer`)
@@ -19,6 +28,9 @@ export class WorkspaceConflictError extends Error {
 
   /**
    * Recognizes the public structural contract across duplicated SDK packages.
+   *
+   * When `workspaceId` is supplied, the candidate must match that exact durable
+   * identity in addition to carrying the stable code.
    */
   static is(value: unknown, workspaceId?: string): value is WorkspaceConflictError {
     if (typeof value !== "object" || value === null) {

--- a/sdk/src/components/workspace/workspace-provider.ts
+++ b/sdk/src/components/workspace/workspace-provider.ts
@@ -1,6 +1,12 @@
+/** Normalized revision selection passed from `Workspace` to its provider. */
 export interface WorkspaceLoadRequest {
+  /** Relative globs excluded from restoration; empty means no exclusions. */
   readonly exclude: readonly string[]
+
+  /** Relative globs limiting restored files; omission selects all files. */
   readonly include?: readonly string[]
+
+  /** `"current"` or one non-empty provider revision identifier to restore. */
   readonly revision: "current" | string
 }
 
@@ -8,20 +14,48 @@ export interface WorkspaceLoadRequest {
  * Provider-owned request for one durable Workspace materialization.
  */
 export interface WorkspaceAcquireRequest {
+  /** Unique identity of the AML evaluation requesting materialization. */
   readonly evaluationId: string
+
+  /** Non-empty normalized durable Workspace identity. */
   readonly id: string
+
+  /**
+   * Revision load policy.
+   *
+   * `false` requests an empty materialization; an object requests one revision.
+   * AML runtime calls provide one of those normalized forms.
+   */
   readonly load?: false | WorkspaceLoadRequest
+
+  /** Whether the provider should acquire writer authority; defaults to `true`. */
   readonly lock?: boolean
+
+  /** Whether AML may later call `save` for this lease. */
   readonly save?: boolean
+
+  /** Evaluation signal covering acquisition and materialization work. */
   readonly signal: AbortSignal
 }
 
+/** Complete normalized publication request passed to a Workspace lease. */
 export interface WorkspaceSaveRequest {
+  /** Relative globs excluded from publication; empty means none. */
   readonly exclude: readonly string[]
+
+  /** Whether `.gitignore` rules participate in snapshot selection. */
   readonly gitignore: boolean
+
+  /** Relative globs limiting publication; omission considers all files. */
   readonly include?: readonly string[]
+
+  /** Outcome of descendant evaluation that triggered this save policy. */
   readonly outcome: "failure" | "success"
+
+  /** Positive number of revisions retained, including the newly published one. */
   readonly retention: number
+
+  /** Evaluation signal that must remain active throughout publication. */
   readonly signal: AbortSignal
 }
 
@@ -29,17 +63,29 @@ export interface WorkspaceSaveRequest {
  * Provider-owned materialization and lifecycle authority returned to AML.
  */
 export interface WorkspaceLease<Handle = unknown> {
+  /** Runtime-visible materialized directory observed by descendants. */
   readonly directory: string
+
+  /** Opaque provider data for compatible Sandbox transfer or mounting. */
   readonly handle: Handle
+
+  /** Stable non-empty identity of this acquired materialization lease. */
   readonly id: string
 
   /**
    * Relinquishes locks and temporary materialization resources.
+   *
+   * Calls must be safe to repeat and must relinquish authority even if cleanup
+   * or provider reconciliation reports an error.
    */
   release(): Promise<void>
 
   /**
    * Persists the current materialization to its durable backend.
+   *
+   * AML passes a normalized request when saving an authored Workspace. The
+   * optional argument preserves the low-level provider seam; implementations
+   * should document their defaults for direct calls.
    */
   save(request?: WorkspaceSaveRequest): Promise<void>
 }
@@ -54,10 +100,14 @@ export interface WorkspaceLease<Handle = unknown> {
  * above this boundary.
  */
 export interface WorkspaceProvider<Handle = unknown> {
+  /** Non-empty normalized provider identifier used in errors and references. */
   readonly name: string
 
   /**
    * Materializes one durable Workspace or rejects an active-writer conflict.
+   *
+   * A pre-aborted signal must start no work. Partial materialization failures
+   * must release any acquired lock or temporary resource before rejecting.
    */
   acquire(request: WorkspaceAcquireRequest): Promise<WorkspaceLease<Handle>>
 }
@@ -66,6 +116,7 @@ export interface WorkspaceProvider<Handle = unknown> {
  * Stable descriptive provider identity without acquisition authority.
  */
 export interface WorkspaceProviderReference {
+  /** Stable descriptive provider name without acquisition authority. */
   readonly name: string
 }
 
@@ -76,11 +127,24 @@ export interface WorkspaceProviderReference {
  * Lifecycle methods remain private to AML.
  */
 export interface WorkspaceMaterializationReference<Handle = unknown> {
+  /** Normalized logical cwd selected by the authored Workspace. */
   readonly cwd: string
+
+  /** Runtime-visible materialization directory to attach or synchronize. */
   readonly directory: string
+
+  /** Opaque provider data available for compatible transfer optimizations. */
   readonly handle: Handle
+
+  /** Identity of this acquired materialization lease. */
   readonly leaseId: string
+
+  /** Descriptive provider identity without `acquire` authority. */
   readonly provider: WorkspaceProviderReference
+
+  /** Authored durable Workspace identity shared across revisions and retries. */
   readonly workspaceId: string
+
+  /** Writable sibling-Sandbox coordination policy selected by the Workspace. */
   readonly writeConcurrency: "parallel" | "serial"
 }

--- a/sdk/src/components/workspace/workspace.tsx
+++ b/sdk/src/components/workspace/workspace.tsx
@@ -1,20 +1,68 @@
 import { AmlNode, type AmlRenderable } from "../../core/aml-node.js"
 import type { WorkspaceProvider } from "./workspace-provider.js"
 
+/** Selects and filters the durable revision loaded before Workspace children run. */
 export interface WorkspaceLoadOptions {
+  /**
+   * Relative forward-slash globs removed from the load selection.
+   *
+   * Defaults to an empty list. Patterns cannot use negation, absolute paths,
+   * backslashes, or parent traversal.
+   */
   readonly exclude?: readonly string[]
+
+  /**
+   * Relative forward-slash globs that limit which files are loaded.
+   *
+   * Omission includes every file not removed by `exclude`.
+   */
   readonly include?: readonly string[]
+
+  /**
+   * Revision identifier to materialize.
+   *
+   * Defaults to `"current"`. A supplied identifier must be non-empty and
+   * normalized; providers define how immutable revision IDs are represented.
+   */
   readonly revision?: "current" | string
 }
 
+/** Controls if and how a Workspace publishes a new durable revision. */
 export interface WorkspaceSaveOptions {
+  /**
+   * Relative forward-slash globs removed from the save selection.
+   *
+   * Defaults to an empty list and follows the same normalization rules as load
+   * patterns.
+   */
   readonly exclude?: readonly string[]
+
+  /**
+   * Whether `.gitignore` rules participate in the save selection.
+   *
+   * Defaults to `true`.
+   */
   readonly gitignore?: boolean
+
+  /**
+   * Relative forward-slash globs that limit which files are saved.
+   *
+   * Omission considers every file not removed by `exclude` or `.gitignore`.
+   */
   readonly include?: readonly string[]
+
+  /**
+   * Descendant outcome on which AML publishes a revision.
+   *
+   * Defaults to `"success"`. `"always"` also saves after ordinary descendant
+   * failure, but cancellation never triggers a save.
+   */
   readonly on?: "always" | "success"
 
   /**
    * Total revisions retained, including the newly published current revision.
+   *
+   * Defaults to `1` and must be a positive safe integer.
    */
   readonly retention?: number
 }
@@ -23,18 +71,76 @@ export interface WorkspaceSaveOptions {
  * Filesystem isolation, optional durable state, and authored Workspace subtree.
  */
 export interface WorkspaceProps {
+  /**
+   * AML values evaluated inside the acquired materialization.
+   *
+   * Omission evaluates an empty scope while still applying configured load,
+   * save, and release behavior.
+   */
   readonly children?: AmlRenderable
+
+  /**
+   * Portable logical working directory exposed to descendants.
+   *
+   * Defaults to `"."` within the materialization and cannot escape it.
+   */
   readonly cwd?: string
+
+  /**
+   * Non-empty normalized durable Workspace identity.
+   *
+   * AML generates a UUID when omitted. Supply a stable ID when later runs must
+   * reopen the same revisions.
+   */
   readonly id?: string
+
+  /**
+   * Revision materialization policy applied before descendants run.
+   *
+   * Defaults to `true`, which loads the current revision without filters.
+   * `false` starts from an empty provider materialization.
+   */
   readonly load?: boolean | WorkspaceLoadOptions
+
+  /**
+   * Whether acquisition requests exclusive durable-writer coordination.
+   *
+   * Defaults to `true`. Providers define the lock implementation and report a
+   * `WorkspaceConflictError` when a competing acquisition cannot proceed.
+   */
   readonly lock?: boolean
+
+  /**
+   * Provider that materializes and optionally persists this Workspace.
+   *
+   * When omitted, AML uses `AmlRuntimeOptions.workspaceProvider`. Evaluation
+   * fails if neither location supplies a provider.
+   */
   readonly provider?: WorkspaceProvider
+
+  /**
+   * Durable publication policy applied before provider release.
+   *
+   * Defaults to `false`. `true` uses the `WorkspaceSaveOptions` defaults; an
+   * options object enables filtering, outcome, retention, and gitignore policy.
+   */
   readonly save?: boolean | WorkspaceSaveOptions
+
+  /**
+   * Coordination policy for writable sibling Sandboxes in this materialization.
+   *
+   * Defaults to `"serial"`. `"parallel"` permits concurrent writers and makes
+   * conflict safety the application and provider's responsibility.
+   */
   readonly writeConcurrency?: "parallel" | "serial"
 }
 
 /**
- * Scopes one materialization to its descendant work.
+ * Acquires one top-level materialization and scopes it to descendant work.
+ *
+ * AML loads before evaluating children, applies the outcome-aware save policy,
+ * and releases the provider lease exactly once. An evaluation supports at most
+ * one Workspace boundary, which must be the top-level resource scope.
  */
 export function Workspace(_props: WorkspaceProps): never {
   throw new Error("<Workspace> can only be evaluated by AmlRuntime")

--- a/sdk/src/core/aml-event-subscriber.ts
+++ b/sdk/src/core/aml-event-subscriber.ts
@@ -5,7 +5,10 @@ import type { TraceSink } from "../observability/trace-sink.js"
  * Announces that one runtime evaluation is ready to execute its AML tree.
  */
 export interface AmlEvaluationStartEvent {
+  /** Opaque identifier shared by every event from this evaluation. */
   readonly runId: string
+
+  /** Evaluation-scoped signal that providers and listeners may observe. */
   readonly signal: AbortSignal
 }
 
@@ -13,9 +16,16 @@ export interface AmlEvaluationStartEvent {
  * Announces that one runtime evaluation has settled and is finishing cleanup.
  */
 export interface AmlEvaluationFinishEvent {
+  /** Failure that ended the evaluation; present only when `status` is `"error"`. */
   readonly error?: unknown
+
+  /** Opaque identifier shared by every event from this evaluation. */
   readonly runId: string
+
+  /** Evaluation-scoped signal, including any cancellation reason. */
   readonly signal: AbortSignal
+
+  /** Whether AML evaluation and owned resource cleanup completed successfully. */
   readonly status: "error" | "ok"
 }
 
@@ -23,11 +33,17 @@ export interface AmlEvaluationFinishEvent {
  * Maps every public runtime event to its immutable payload.
  */
 export interface AmlEventMap {
+  /** Payload emitted after evaluation and owned cleanup settle. */
   readonly finish: AmlEvaluationFinishEvent
+
+  /** Payload emitted immediately before AML begins evaluating the authored tree. */
   readonly start: AmlEvaluationStartEvent
+
+  /** Immutable observability event emitted during evaluation. */
   readonly trace: AmlTraceEvent
 }
 
+/** Names accepted by {@link AmlEventSubscriber.on} and `once`. */
 export type AmlEventName = keyof AmlEventMap
 
 /**
@@ -47,7 +63,17 @@ export type AmlEventListener<Name extends AmlEventName> = Name extends "trace"
  * events or observe concurrent evaluations through this boundary.
  */
 export interface AmlEventSubscriber {
+  /**
+   * Registers a listener for every matching event in this evaluation scope.
+   *
+   * Returns an idempotent function that unregisters this exact listener.
+   */
   on<Name extends AmlEventName>(name: Name, listener: AmlEventListener<Name>): () => void
 
+  /**
+   * Registers a listener that removes itself before its first matching event.
+   *
+   * Returns a function that can cancel the pending registration.
+   */
   once<Name extends AmlEventName>(name: Name, listener: AmlEventListener<Name>): () => void
 }

--- a/sdk/src/core/aml-json-value.ts
+++ b/sdk/src/core/aml-json-value.ts
@@ -1,5 +1,10 @@
 /**
- * Portable data that may cross an AML provider boundary.
+ * Recursively immutable JSON-compatible data that may cross an AML provider
+ * boundary.
+ *
+ * Values exclude `undefined`, `bigint`, symbols, functions, class instances,
+ * and cyclic object graphs. Provider and tool contracts use this shape so data
+ * can be snapshotted without depending on application object identity.
  */
 export type AmlJsonValue =
   | boolean
@@ -7,4 +12,7 @@ export type AmlJsonValue =
   | number
   | string
   | readonly AmlJsonValue[]
-  | { readonly [key: string]: AmlJsonValue }
+  | {
+      /** JSON object properties, addressed by their serialized string keys. */
+      readonly [key: string]: AmlJsonValue
+    }

--- a/sdk/src/core/aml-node.ts
+++ b/sdk/src/core/aml-node.ts
@@ -1,5 +1,7 @@
 const AML_NODE_BRAND = Symbol.for("@aml-jsx/sdk/node")
 const AML_PRIMITIVE_KIND = Symbol.for("@aml-jsx/sdk/primitive-kind")
+
+/** Runtime-owned discriminator assigned to each built-in AML primitive. */
 type AmlPrimitiveKind =
   | "agent"
   | "context"
@@ -16,11 +18,17 @@ type AmlPrimitiveKind =
 
 /**
  * JSX values that intentionally contribute no AML output.
+ *
+ * As in UI-oriented JSX runtimes, booleans are treated as empty markers rather
+ * than rendered as the strings `"true"` or `"false"`.
  */
 export type AmlEmpty = boolean | null | undefined
 
 /**
- * Complete set of values accepted by the asynchronous AML evaluator.
+ * Complete recursive set of values accepted by the asynchronous AML evaluator.
+ *
+ * Strings are preserved, numbers are stringified, arrays are evaluated in
+ * authored order, promises are awaited, and {@link AmlEmpty} values disappear.
  */
 export type AmlRenderable =
   | AmlEmpty
@@ -32,14 +40,21 @@ export type AmlRenderable =
 
 /**
  * Function-component contract used by the AML JSX runtime.
+ *
+ * A component may return any renderable value directly or through a Promise.
+ * Components run once when their node is evaluated; AML does not rerender them.
  */
 export type AmlComponent<Props = Record<string, unknown>> = (props: Props) => AmlRenderable
 
 /**
  * Immutable component props after JSX child normalization.
+ *
+ * `children` is optional because self-closing components receive no child
+ * value. Multiple authored children arrive as an immutable-compatible array.
  */
 export type AmlNodeProps<Props = Record<string, unknown>> = Readonly<
   Props & {
+    /** Authored nested JSX content after automatic-runtime normalization. */
     children?: AmlRenderable
   }
 >
@@ -51,14 +66,28 @@ export type AmlNodeProps<Props = Record<string, unknown>> = Readonly<
  * lets the runtime preserve ordering, depth, and future execution scopes.
  */
 export class AmlNode<Props = Record<string, unknown>> {
+  /** Cross-package brand used by {@link AmlNode.is}; not application metadata. */
   declare readonly $$typeof: symbol
+
+  /** Frozen snapshot of the JSX props captured when this node was constructed. */
   readonly props: AmlNodeProps<Props>
+
+  /** Function component to invoke when the runtime reaches this node. */
   readonly type: AmlComponent<Props>
 
   /**
    * Captures a component reference and immutable props without invoking it.
+   *
+   * JSX authors normally receive nodes from the automatic JSX runtime rather
+   * than constructing this class directly.
    */
-  constructor(type: AmlComponent<Props>, props: Props & { children?: AmlRenderable }) {
+  constructor(
+    type: AmlComponent<Props>,
+    props: Props & {
+      /** Authored nested JSX content after automatic-runtime normalization. */
+      children?: AmlRenderable
+    }
+  ) {
     this.type = type
     this.props = Object.freeze({ ...props })
     Object.defineProperty(this, "$$typeof", { value: AML_NODE_BRAND })
@@ -67,6 +96,8 @@ export class AmlNode<Props = Record<string, unknown>> {
 
   /**
    * Recognizes AML nodes across physical copies of the SDK package.
+   *
+   * Returns `false` for lookalike objects that do not carry AML's global brand.
    */
   static is(value: unknown): value is AmlNode {
     return typeof value === "object" && value !== null && Reflect.get(value, "$$typeof") === AML_NODE_BRAND
@@ -74,6 +105,9 @@ export class AmlNode<Props = Record<string, unknown>> {
 
   /**
    * Marks a built-in component for runtime-owned primitive evaluation.
+   *
+   * This is an SDK implementation hook, not a supported way for applications
+   * to define new primitive kinds.
    */
   static markPrimitive(component: AmlComponent<any>, kind: AmlPrimitiveKind): void {
     Object.defineProperty(component, AML_PRIMITIVE_KIND, {
@@ -83,6 +117,8 @@ export class AmlNode<Props = Record<string, unknown>> {
 
   /**
    * Returns a previously registered primitive kind without invoking the component.
+   *
+   * Returns `undefined` for ordinary application components.
    */
   static primitiveKind(component: AmlComponent<any>): AmlPrimitiveKind | undefined {
     const kind = (

--- a/sdk/src/core/aml-runtime.ts
+++ b/sdk/src/core/aml-runtime.ts
@@ -214,74 +214,130 @@ type EvaluationFrame =
  */
 export interface AmlRuntimeOptions {
   /**
-   * Optional exact-name MCP server allowlist.
+   * Exact MCP server names that authored `<Mcp>` components may grant.
+   *
+   * Omit this option to allow every otherwise valid server. An empty array
+   * denies all authored MCP servers. Names must be non-empty, already-trimmed
+   * strings and are matched case-sensitively.
    */
   readonly allowedMcpServers?: readonly string[]
 
   /**
-   * Optional exact-name capability allowlist.
+   * Exact JavaScript tool names that authored `<Tool>` components may grant.
+   *
+   * Omit this option to allow every otherwise valid tool. An empty array
+   * denies all authored tools. Names must be non-empty, already-trimmed
+   * strings and are matched case-sensitively. Runtime-owned capabilities,
+   * such as Loop state, are not filtered by this authoring allowlist.
    */
   readonly allowedTools?: readonly string[]
 
   /**
-   * Default provider for Agents without an explicit provider prop.
+   * Provider used by each `<Agent>` that does not set its own `provider` prop.
+   *
+   * No provider is configured by default. Evaluating an Agent without either
+   * source of provider then throws an {@link EvaluationError}.
    */
   readonly agentProvider?: AgentProvider
 
   /**
-   * Base directory for relative local Skill files and host Script execution.
+   * Host directory used to resolve relative `<Skill src>` paths and as the
+   * default working directory for host-executed `<Script>` components.
+   *
+   * Defaults to `process.cwd()` when the runtime is constructed. An active
+   * Sandbox supplies its effective cwd to nested Scripts instead. A Workspace
+   * affects Script cwd only when it supplies the default cwd of an enclosing
+   * Sandbox.
    */
   readonly cwd?: string
 
   /**
-   * Maximum provider-backed Agent sessions. Zero disables the limit.
+   * Maximum number of provider-backed Agent sessions in one evaluation.
+   *
+   * Defaults to `32`. Use `0` to disable this limit. The value must be a
+   * non-negative safe integer and includes Agent calls made by nested
+   * component-local `evaluate()` operations.
    */
   readonly maxAgentCalls?: number
 
   /**
-   * Maximum active Agent provider calls. Zero disables the limit.
+   * Maximum number of Agent provider calls that may be active concurrently in
+   * one evaluation.
+   *
+   * Defaults to `4`. Use `0` to disable this limit. The value must be a
+   * non-negative safe integer. Calls beyond the limit wait for capacity rather
+   * than failing solely because the limit is occupied.
    */
   readonly maxConcurrentAgents?: number
 
   /**
-   * Maximum nested JSX node depth. Zero disables the limit.
+   * Maximum semantic nesting depth of JSX nodes in one evaluation.
    *
-   * Arrays and Promises do not add semantic depth; Fragments and components do.
+   * Defaults to `16`. Use `0` to disable this limit. The value must be a
+   * non-negative safe integer. Arrays and Promises do not add semantic depth;
+   * Fragments and components do.
    */
   readonly maxDepth?: number
 
   /**
-   * Maximum committed Loop transitions. Zero disables the limit.
+   * Maximum committed state transitions across all `<Loop>` components in one
+   * evaluation.
+   *
+   * Defaults to `16`. Use `0` to disable this limit. The value must be a
+   * non-negative safe integer.
    */
   readonly maxStateTransitions?: number
 
   /**
-   * Maximum authored inputs in one Agent session. Zero disables the limit.
+   * Maximum authored inputs sent during one Agent provider session.
+   *
+   * Defaults to `16`. Use `0` to disable this limit. The value must be a
+   * non-negative safe integer. The initial prompt and each `<FollowUp>` count
+   * as turns; provider tool-call traffic does not consume authored turns.
    */
   readonly maxTurnsPerAgent?: number
 
   /**
-   * Reports trace-consumer failures without changing workflow behavior.
+   * Handles exceptions and rejected promises produced by trace listeners.
+   *
+   * Trace observation never changes workflow success. When omitted, listener
+   * failures are ignored. The handler receives the error and the redacted event
+   * that was being observed.
    */
   readonly onTraceError?: TraceErrorHandler
 
   /**
-   * Default provider for outer Sandboxes without an explicit provider prop.
+   * Provider used by an outer `<Sandbox>` that does not set its own `provider`.
+   *
+   * No Sandbox provider is configured by default. Nested Sandboxes inherit the
+   * active lease and cannot switch providers.
    */
   readonly sandboxProvider?: SandboxProvider
 
   /**
-   * First system fragment supplied to every Agent in this runtime.
+   * Runtime-wide system instruction prepended to every Agent request.
+   *
+   * Defaults to no runtime instruction. This fragment precedes the Agent's
+   * `system` prop and nested `<System>` fragments in deterministic order.
    */
   readonly system?: string
 
   /**
-   * Receives immutable execution events for each evaluation.
+   * Listener that receives immutable trace events from every evaluation run by
+   * this runtime.
+   *
+   * Omitted by default. Trace delivery is observational and is not awaited by
+   * workflow execution. Content is redacted unless the sink explicitly opts in
+   * through the {@link TraceSink} contract.
    */
   readonly trace?: TraceSink
 
   /**
-   * Default provider for the one top-level Workspace in an evaluation.
+   * Provider used by the single top-level `<Workspace>` in an evaluation when
+   * that component does not set its own `provider`.
+   *
+   * No Workspace provider is configured by default. Nested Workspaces are not
+   * supported because one evaluation owns at most one durable materialization.
    */
   readonly workspaceProvider?: WorkspaceProvider
 }
@@ -292,12 +348,22 @@ export interface AmlRuntimeOptions {
 export interface AmlEvaluationOptions {
   /**
    * Caller-owned cancellation signal for this complete evaluation.
+   *
+   * When omitted, the runtime creates a never-aborted signal for the call.
+   * Cancellation is propagated to providers and resource cleanup. If already
+   * aborted, `evaluate()` rejects before starting the AML tree.
    */
   readonly signal?: AbortSignal
 }
 
 /**
- * Evaluates one authored AML tree into its final text.
+ * Evaluates authored AML trees with captured providers, policy, limits, and
+ * runtime-wide event listeners.
+ *
+ * A runtime is reusable and supports concurrent `evaluate()` calls. Each call
+ * owns its cancellation, budgets, Context state, resources, and trace identity;
+ * only the immutable constructor configuration and registered listeners are
+ * shared.
  */
 export class AmlRuntime {
   readonly #agentExecutor: AgentExecutor
@@ -318,7 +384,11 @@ export class AmlRuntime {
   readonly #workspaceEvaluator: WorkspaceEvaluator
 
   /**
-   * Captures one immutable set of runtime limits and Agent defaults.
+   * Captures one immutable set of provider defaults, capability policy, safety
+   * limits, and trace configuration.
+   *
+   * Mutable option arrays are copied during construction. Invalid numeric
+   * limits, capability names, or callback values throw synchronously.
    */
   constructor(options: AmlRuntimeOptions = {}) {
     const maxAgentCalls = options.maxAgentCalls ?? 32
@@ -373,24 +443,35 @@ export class AmlRuntime {
   }
 
   /**
-   * Registers one listener for every evaluation executed by this runtime.
+   * Registers a listener for each matching event emitted by this runtime.
+   *
+   * `start` and `finish` listeners are awaited at their lifecycle boundaries;
+   * `trace` listeners are observational and are not awaited. The returned
+   * function unregisters this exact listener and is safe to call repeatedly.
    */
   on<Name extends AmlEventName>(name: Name, listener: AmlEventListener<Name>): () => void {
     return this.#events.on(name, listener)
   }
 
   /**
-   * Registers one listener for the next matching runtime event.
+   * Registers a listener for the next matching event emitted by this runtime.
+   *
+   * The listener unregisters before it is invoked, so recursive or concurrent
+   * event delivery cannot invoke it twice. The returned function may be used to
+   * cancel the registration before that event occurs.
    */
   once<Name extends AmlEventName>(name: Name, listener: AmlEventListener<Name>): () => void {
     return this.#events.once(name, listener)
   }
 
   /**
-   * Resolves one AML tree post-order into its final string output.
+   * Resolves one AML tree to its final string output.
    *
-   * The evaluator uses an explicit frame stack so asynchronous components and
-   * deeply nested trees do not depend on JavaScript recursion.
+   * Empty values contribute no text, arrays preserve authored order, and
+   * numbers are stringified. Components and promises are resolved
+   * asynchronously. The returned promise rejects on invalid AML, provider or
+   * resource failures, exhausted limits, cycles, or cancellation. Cleanup is
+   * attempted before the promise settles.
    */
   async evaluate(value: AmlRenderable, options: AmlEvaluationOptions = {}): Promise<string> {
     const signal = options.signal ?? new AbortController().signal

--- a/sdk/src/core/evaluate.ts
+++ b/sdk/src/core/evaluate.ts
@@ -8,9 +8,29 @@ import { ComponentEvaluationContext } from "./component-evaluation-context.js"
  * Evaluates AML as data inside the currently active function component.
  *
  * This is an ordinary asynchronous call. It never suspends or rerenders the
- * component, and detached calls reject after AML observes its completion.
+ * component, and detached calls reject after AML observes its completion. The
+ * subtree inherits the current Context, Workspace, Sandbox, cancellation,
+ * limits, and trace parent.
+ *
+ * With no schema, the promise resolves to rendered text. With an
+ * {@link AmlModelSchema}, the subtree must resolve to exactly one outer Agent
+ * and the promise resolves to that schema's validated output. Calling this
+ * function outside an actively evaluated component throws.
+ *
+ * @param value AML subtree to evaluate within the current component scope.
+ * @param schema Optional Standard Schema contract for structured Agent output.
  */
 export function evaluate(value: AmlRenderable): Promise<string>
+/**
+ * Evaluates one structured Agent subtree inside the current function component.
+ *
+ * The supplied Standard Schema is forwarded to the outer Agent provider and
+ * validates its result. The promise resolves to the schema's inferred output
+ * type rather than rendered text.
+ *
+ * @param value AML subtree that must resolve to exactly one outer Agent.
+ * @param schema Standard Schema contract for the Agent's structured output.
+ */
 export function evaluate<Schema extends AmlModelSchema<unknown, unknown>>(
   value: AmlRenderable,
   schema: Schema

--- a/sdk/src/core/evaluation-error.ts
+++ b/sdk/src/core/evaluation-error.ts
@@ -1,6 +1,12 @@
 /**
  * Reports invalid authored AML values and evaluator invariants.
+ *
+ * Use `instanceof EvaluationError` to distinguish structural workflow errors,
+ * such as misplaced primitives, exceeded evaluation limits, cycles, or invalid
+ * component composition, from provider and application failures passed through
+ * by the runtime.
  */
 export class EvaluationError extends Error {
+  /** Stable error name for logs and error-boundary classification. */
   override readonly name = "EvaluationError"
 }

--- a/sdk/src/core/process-signal-cancellation.ts
+++ b/sdk/src/core/process-signal-cancellation.ts
@@ -3,10 +3,19 @@ import { clearTimeout, setTimeout } from "node:timers"
 
 const DEFAULT_CLEANUP_DEADLINE_MS = 10_000
 
+/** Process interrupts handled by {@link ProcessSignalCancellation}. */
 export type ProcessSignal = "SIGINT" | "SIGTERM"
 
+/** Construction options for {@link ProcessSignalCancellation}. */
 export interface ProcessSignalCancellationOptions {
-  /** Maximum cleanup time before forced exit. Defaults to 10 seconds. */
+  /**
+   * Maximum time allowed for cancellation-aware cleanup before the process is
+   * forcibly terminated with the signal's conventional exit code.
+   *
+   * Defaults to `10_000` milliseconds. Use `0` to schedule forced termination
+   * immediately after the abort is dispatched. The value must be a
+   * non-negative safe integer.
+   */
   readonly cleanupDeadlineMs?: number
 }
 
@@ -30,6 +39,12 @@ export class ProcessSignalCancellation {
   readonly #host: ProcessSignalHost
   #receivedSignal: ProcessSignal | undefined
 
+  /**
+   * Installs `SIGINT` and `SIGTERM` listeners on the current Node.js process.
+   *
+   * Each instance must be disposed after the associated evaluation and cleanup
+   * finish. Construction throws for an invalid cleanup deadline.
+   */
   constructor(options?: Readonly<ProcessSignalCancellationOptions>)
   constructor(options: Readonly<ProcessSignalCancellationOptions> = {}, host: ProcessSignalHost = process) {
     if (
@@ -45,14 +60,31 @@ export class ProcessSignalCancellation {
     host.on("SIGTERM", this.#onSigterm)
   }
 
+  /**
+   * Conventional process exit code for the first received signal.
+   *
+   * Returns `undefined` until interrupted, `130` for `SIGINT`, and `143` for
+   * `SIGTERM`. Applications can assign this value to `process.exitCode` after
+   * graceful cleanup.
+   */
   get exitCode(): number | undefined {
     return this.#receivedSignal === undefined ? undefined : signalExitCode(this.#receivedSignal)
   }
 
+  /**
+   * Signal aborted when the process first receives `SIGINT` or `SIGTERM`.
+   *
+   * Its reason is an Error naming the received process signal.
+   */
   get signal(): AbortSignal {
     return this.#abortController.signal
   }
 
+  /**
+   * Removes installed process listeners and cancels a pending forced-exit timer.
+   *
+   * Disposing does not reset or replace the exposed AbortSignal.
+   */
   dispose(): void {
     this.#host.off("SIGINT", this.#onSigint)
     this.#host.off("SIGTERM", this.#onSigterm)

--- a/sdk/src/core/trace-identity.ts
+++ b/sdk/src/core/trace-identity.ts
@@ -5,7 +5,12 @@
  * changing the provider contract.
  */
 export interface AmlTraceIdentity {
+  /** Span that contains this provider session; omitted only for a root span. */
   readonly parentSpanId?: string
+
+  /** Opaque identifier shared by every trace event in one AML evaluation. */
   readonly runId: string
+
+  /** Opaque identifier of the Agent span associated with this provider session. */
   readonly spanId: string
 }

--- a/sdk/src/jsx-dev-runtime.ts
+++ b/sdk/src/jsx-dev-runtime.ts
@@ -7,10 +7,23 @@ import { Fragment, jsx } from "./jsx-runtime.js"
  *
  * AML does not currently retain source metadata or keys, but accepting the
  * complete transform signature keeps development and production semantics equal.
+ * Components are captured as immutable nodes and are invoked only by evaluation.
+ *
+ * @param type Function component to invoke during evaluation.
+ * @param props Component props captured by the node; `null` becomes an empty object.
+ * @param _key JSX transform key, currently ignored by AML.
+ * @param _isStaticChildren Development-transform child stability hint, currently ignored.
+ * @param _source Development source location, currently ignored.
+ * @param _self Development owner value, currently ignored.
  */
 export function jsxDEV<Props>(
   type: AmlComponent<Props>,
-  props: (Props & { children?: AmlRenderable }) | null,
+  props:
+    | (Props & {
+        /** Authored nested JSX content supplied to the component. */
+        children?: AmlRenderable
+      })
+    | null,
   _key?: string,
   _isStaticChildren?: boolean,
   _source?: unknown,
@@ -25,12 +38,20 @@ export { Fragment }
  * TypeScript JSX contracts exposed by the AML development transform.
  */
 export namespace JSX {
+  /** Value produced by an AML JSX expression. */
   export type Element = AmlNode
+
+  /** Function components accepted in AML JSX tag position. */
   export type ElementType = AmlComponent<any>
 
+  /** Compiler hook that maps nested JSX content to the `children` prop. */
   export interface ElementChildrenAttribute {
+    /** Property name used by the JSX transform for authored children. */
     children: unknown
   }
 
+  /**
+   * AML has no string-named intrinsic elements; every JSX tag is a component.
+   */
   export interface IntrinsicElements {}
 }

--- a/sdk/src/jsx-runtime.ts
+++ b/sdk/src/jsx-runtime.ts
@@ -1,11 +1,16 @@
 import { AmlNode, type AmlComponent, type AmlRenderable } from "./core/aml-node.js"
 
+/** Props accepted by the JSX Fragment implementation. */
 interface FragmentProps {
+  /** Renderable values grouped without adding an AML execution boundary. */
   children?: AmlRenderable
 }
 
 /**
  * Groups AML children without adding text or execution behavior.
+ *
+ * A Fragment preserves the authored child order and returns `undefined` when
+ * no children are provided.
  */
 export function Fragment({ children }: FragmentProps): AmlRenderable {
   return children
@@ -13,10 +18,22 @@ export function Fragment({ children }: FragmentProps): AmlRenderable {
 
 /**
  * Constructs an AML descriptor for TypeScript's automatic JSX runtime.
+ *
+ * Components are not invoked during construction. The optional JSX key is
+ * accepted for transform compatibility but AML does not retain or interpret it.
+ *
+ * @param type Function component to invoke during evaluation.
+ * @param props Component props captured by the node; `null` becomes an empty object.
+ * @param _key JSX transform key, currently ignored by AML.
  */
 export function jsx<Props>(
   type: AmlComponent<Props>,
-  props: (Props & { children?: AmlRenderable }) | null,
+  props:
+    | (Props & {
+        /** Authored nested JSX content supplied to the component. */
+        children?: AmlRenderable
+      })
+    | null,
   _key?: string
 ): AmlNode<Props> {
   return new AmlNode(type, (props ?? {}) as Props & { children?: AmlRenderable })
@@ -24,6 +41,9 @@ export function jsx<Props>(
 
 /**
  * Multi-child transform alias required by TypeScript's automatic JSX runtime.
+ *
+ * It has exactly the same behavior as {@link jsx}; the compiler selects the
+ * alias based on the authored child shape.
  */
 export const jsxs = jsx
 
@@ -31,12 +51,20 @@ export const jsxs = jsx
  * TypeScript JSX contracts exposed by the AML production transform.
  */
 export namespace JSX {
+  /** Value produced by an AML JSX expression. */
   export type Element = AmlNode
+
+  /** Function components accepted in AML JSX tag position. */
   export type ElementType = AmlComponent<any>
 
+  /** Compiler hook that maps nested JSX content to the `children` prop. */
   export interface ElementChildrenAttribute {
+    /** Property name used by the JSX transform for authored children. */
     children: unknown
   }
 
+  /**
+   * AML has no string-named intrinsic elements; every JSX tag is a component.
+   */
   export interface IntrinsicElements {}
 }

--- a/sdk/src/observability/create-console-tracer.ts
+++ b/sdk/src/observability/create-console-tracer.ts
@@ -2,22 +2,37 @@ import type { AmlTraceAttribute, AmlTraceEvent } from "./trace-event.js"
 import type { TraceSink } from "./trace-sink.js"
 
 /**
- * Console tracer configuration.
+ * Configuration for {@link createConsoleTracer}.
  */
 export interface ConsoleTracerOptions {
   /**
-   * Includes prompt and output fields explicitly marked sensitive by AML.
+   * Whether trace attributes may include prompts, output, error messages, and
+   * other fields explicitly marked sensitive by AML.
+   *
+   * Defaults to `false`. Enable only when the destination is approved to retain
+   * model-facing or application content.
    */
   readonly captureContent?: boolean
 
   /**
-   * Replaces console.log for deterministic tests and custom terminals.
+   * Writes one already-formatted trace line.
+   *
+   * Defaults to `console.log`. A returned promise is observed through the
+   * runtime's trace-error channel but is never awaited by workflow execution.
    */
   readonly write?: (line: string) => unknown
 }
 
 /**
- * Creates a compact tree-oriented trace consumer for local development.
+ * Creates a dependency-free, tree-oriented {@link TraceSink} for local
+ * development and terminal logs.
+ *
+ * The sink indents events by span ancestry, prints lifecycle markers and
+ * attributes without terminal color codes, and releases per-run state when the
+ * evaluation span ends. High-volume ACP message, thought, and tool-update
+ * chunks are omitted from this view; they remain available to other sinks.
+ *
+ * @param options Content policy and output destination. Both are captured once.
  */
 export function createConsoleTracer(options: ConsoleTracerOptions = {}): TraceSink {
   const captureContent = options.captureContent ?? false

--- a/sdk/src/observability/create-trace-summary-collector.ts
+++ b/sdk/src/observability/create-trace-summary-collector.ts
@@ -7,43 +7,125 @@ interface ActiveTraceSummary {
   readonly spans: AmlTraceSpanEndEvent[]
 }
 
+/** Timing totals accumulated for one category of completed trace spans. */
 interface TraceSpanAggregate {
+  /** Number of matching completed spans observed in the evaluation. */
   readonly count: number
+
+  /** Longest matching span duration; omitted when `count` is zero. */
   readonly slowestMs?: number
+
+  /** Sum of all matching span durations in milliseconds. */
   readonly totalDurationMs: number
 }
 
+/** Result of one completed Agent cleanup span. */
 interface TraceCleanupOutcome {
+  /** Wall-clock duration of one Agent cleanup span in milliseconds. */
   readonly durationMs: number
+
+  /** Whether that cleanup span completed without an error. */
   readonly status: "error" | "ok"
 }
 
-/** Content-free measurements derived from one completed evaluation trace. */
+/**
+ * Content-free measurements derived from one completed evaluation trace.
+ *
+ * Aggregates describe only AML and ACP boundaries present in the public trace;
+ * they do not infer model calls, retries, cache behavior, cost, or billing.
+ */
 export interface TraceSummary {
+  /** Provider-reported ACP tool-call starts, separate from AML `<Tool>` spans. */
   readonly acpToolCalls: {
+    /** Counts keyed by the exact provider-reported capability name. */
     readonly byName: Readonly<Record<string, number>>
+
+    /** Total initial ACP `tool_call` updates, including calls without a name. */
     readonly count: number
   }
+
+  /** Provider session and authored-turn timing aggregates. */
   readonly agents: {
+    /** Complete provider session boundaries, including setup and cleanup. */
     readonly sessions: TraceSpanAggregate
+
+    /** Initial prompt and FollowUp provider request boundaries. */
     readonly turns: TraceSpanAggregate
   }
+
+  /** Timing aggregates for each exact name passed to `withTraceSpan()`. */
   readonly applicationSpans: Readonly<Record<string, TraceSpanAggregate>>
+
+  /** Ordered outcomes of Agent cleanup spans emitted during the evaluation. */
   readonly cleanup: readonly TraceCleanupOutcome[]
+
+  /** Wall-clock duration of the root evaluation span in milliseconds. */
   readonly durationMs: number
+
+  /**
+   * Serialized provider-owned usage objects from successful Agent turns.
+   *
+   * An empty array means no usage was reported; entries promise no portable
+   * token, model-call, cost, cache, or billing fields.
+   */
   readonly providerUsage: readonly string[]
+
+  /** Timing aggregates for resource and process execution boundaries. */
   readonly resources: {
+    /** Completed Sandbox acquisition scopes. */
     readonly sandboxes: TraceSpanAggregate
+
+    /** Completed Script executions. */
     readonly scripts: TraceSpanAggregate
+
+    /** Completed Workspace materialization scopes. */
     readonly workspaces: TraceSpanAggregate
   }
+
+  /** Opaque evaluation identifier used to retrieve and correlate this summary. */
   readonly runId: string
+
+  /** Terminal status copied from the root evaluation span. */
   readonly status: "error" | "ok"
+
+  /** Timing of declarative AML `<Tool>` executions, not provider-native tools. */
   readonly tools: TraceSpanAggregate
 }
 
-/** Derives run-keyed summaries from public immutable trace events. */
-export function createTraceSummaryCollector() {
+/** Run-keyed collector returned by {@link createTraceSummaryCollector}. */
+interface TraceSummaryCollector {
+  /**
+   * Removes a retained completed summary.
+   *
+   * Returns `true` when a summary existed and was removed. Active, incomplete
+   * run state is not affected.
+   */
+  deleteRun(runId: string): boolean
+
+  /**
+   * Returns the completed immutable summary for an explicit evaluation run.
+   *
+   * Returns `undefined` until the evaluation end event has been observed or
+   * after the summary is deleted. There is intentionally no ambiguous
+   * latest-run lookup for runtimes handling concurrent evaluations.
+   */
+  forRun(runId: string): TraceSummary | undefined
+
+  /** Trace sink to register on `AmlRuntimeOptions.trace`. */
+  readonly trace: TraceSink
+}
+
+/**
+ * Creates an in-memory collector that derives content-free, run-keyed summaries
+ * from public immutable trace events.
+ *
+ * Completed summaries remain retained until `deleteRun(runId)` is called. ACP
+ * tool-call counts retain only initial call names and counts, never arguments,
+ * results, prompts, or model text. One provider call routed to an AML `<Tool>`
+ * may correctly appear in both `acpToolCalls` and `tools` because those measure
+ * different boundaries.
+ */
+export function createTraceSummaryCollector(): TraceSummaryCollector {
   const active = new Map<string, ActiveTraceSummary>()
   const completed = new Map<string, TraceSummary>()
 
@@ -75,9 +157,11 @@ export function createTraceSummaryCollector() {
   }
 
   return Object.freeze({
+    /** Removes one retained completed summary without touching active run state. */
     deleteRun(runId: string) {
       return completed.delete(runId)
     },
+    /** Reads one completed summary by its explicit evaluation run id. */
     forRun(runId: string) {
       return completed.get(runId)
     },

--- a/sdk/src/observability/trace-event.ts
+++ b/sdk/src/observability/trace-event.ts
@@ -10,6 +10,10 @@ export type AmlTraceAttribute = boolean | number | string | readonly string[]
 
 /**
  * Execution boundaries represented by paired start and end events.
+ *
+ * `application` is user-defined work measured by `withTraceSpan()`. The other
+ * values identify runtime evaluation, authored component, provider, capability,
+ * and resource boundaries owned by AML.
  */
 export type AmlTraceSpanKind =
   | "application"
@@ -27,6 +31,12 @@ export type AmlTraceSpanKind =
 
 /**
  * Point-in-time events that belong to an existing execution span.
+ *
+ * ACP names report facts observed at the Agent Client Protocol boundary.
+ * `agent.output` reports structured-result submissions, `capability.*` reports
+ * grants, `loop.transition` reports committed state, and `sandbox.process`
+ * reports process lifecycle observations. Event-specific details are carried in
+ * `attributes`; consumers must tolerate new attributes over time.
  */
 export type AmlTraceEventName =
   | "acp.session.cancel"
@@ -45,8 +55,18 @@ export type AmlTraceEventName =
  * Common immutable correlation and ordering fields on every trace event.
  */
 export interface AmlTraceEventBase extends AmlTraceIdentity {
+  /**
+   * Frozen provider-neutral metadata for this event.
+   *
+   * Sensitive values such as prompts, output, and error messages are omitted
+   * unless the receiving {@link TraceSink} enables content capture.
+   */
   readonly attributes: Readonly<Record<string, AmlTraceAttribute>>
+
+  /** Monotonically increasing event order within `runId`, starting at one. */
   readonly sequence: number
+
+  /** Event creation time as Unix epoch milliseconds from `Date.now()`. */
   readonly timestamp: number
 }
 
@@ -54,8 +74,13 @@ export interface AmlTraceEventBase extends AmlTraceIdentity {
  * Announces the start of one attributable execution boundary.
  */
 export interface AmlTraceSpanStartEvent extends AmlTraceEventBase {
+  /** Stable category of the execution boundary being opened. */
   readonly kind: AmlTraceSpanKind
+
+  /** Boundary name; built-in names are stable and application names are caller-owned. */
   readonly name: string
+
+  /** Discriminant identifying the opening half of a span. */
   readonly type: "span.start"
 }
 
@@ -63,10 +88,19 @@ export interface AmlTraceSpanStartEvent extends AmlTraceEventBase {
  * Closes one execution boundary using the identity from its start event.
  */
 export interface AmlTraceSpanEndEvent extends AmlTraceEventBase {
+  /** Elapsed wall-clock duration of the span in milliseconds. */
   readonly durationMs: number
+
+  /** Stable category copied from the matching start event. */
   readonly kind: AmlTraceSpanKind
+
+  /** Boundary name copied from the matching start event. */
   readonly name: string
+
+  /** Whether the boundary completed normally or ended with an error. */
   readonly status: "error" | "ok"
+
+  /** Discriminant identifying the closing half of a span. */
   readonly type: "span.end"
 }
 
@@ -74,11 +108,18 @@ export interface AmlTraceSpanEndEvent extends AmlTraceEventBase {
  * Records one ordered fact inside an existing execution boundary.
  */
 export interface AmlTracePointEvent extends AmlTraceEventBase {
+  /** Stable name describing the fact recorded by this event. */
   readonly name: AmlTraceEventName
+
+  /** Discriminant identifying an instantaneous event rather than a span edge. */
   readonly type: "event"
 }
 
 /**
  * Stable provider-neutral event union emitted by one AML evaluation.
+ *
+ * Narrow on `type` before reading span-only fields, then use `kind` or `name`
+ * for boundary-specific handling. Consumers should order events by `sequence`,
+ * not timestamp, and correlate spans through `spanId` and `parentSpanId`.
  */
 export type AmlTraceEvent = AmlTracePointEvent | AmlTraceSpanEndEvent | AmlTraceSpanStartEvent

--- a/sdk/src/observability/trace-sink.ts
+++ b/sdk/src/observability/trace-sink.ts
@@ -7,11 +7,28 @@ import type { AmlTraceEvent } from "./trace-event.js"
  * consumer into sensitive text fields owned by the portable AML runtime.
  */
 export interface TraceSink {
+  /**
+   * Observes one immutable trace event.
+   *
+   * AML does not await the return value. Synchronous throws and rejected
+   * thenables are routed to `AmlRuntimeOptions.onTraceError` without changing
+   * evaluation success.
+   */
   (event: AmlTraceEvent): unknown
+
+  /**
+   * Whether this sink receives sensitive content fields in trace attributes.
+   *
+   * Defaults to `false` when omitted. AML captures this flag when the listener
+   * is registered; changing it later does not change that registration.
+   */
   readonly captureContent?: boolean
 }
 
 /**
  * Receives a trace-consumer failure through an isolated secondary channel.
+ *
+ * @param error Value thrown or rejected by a trace listener.
+ * @param event Redacted event being delivered when the listener failed.
  */
 export type TraceErrorHandler = (error: unknown, event: AmlTraceEvent) => void

--- a/sdk/src/observability/with-trace-span.ts
+++ b/sdk/src/observability/with-trace-span.ts
@@ -2,7 +2,18 @@ import { ComponentEvaluationContext } from "../core/component-evaluation-context
 
 /**
  * Measures application-owned work beneath the currently active AML component.
- * The callback result and thrown value pass through unchanged.
+ *
+ * AML allocates an `application` span beneath the active component or enclosing
+ * application span and closes it on success, failure, or cancellation. The
+ * callback result and thrown value pass through unchanged. Nested calls remain
+ * correctly parented across asynchronous and concurrent work.
+ *
+ * Calling this outside an active component, including from work detached after
+ * component settlement, throws an EvaluationError. `name` must be a non-empty,
+ * already-trimmed string.
+ *
+ * @param name Caller-owned span name used for traces and summary aggregation.
+ * @param operation Synchronous or asynchronous application work to measure.
  */
 export function withTraceSpan<Result>(name: string, operation: () => PromiseLike<Result> | Result): Promise<Result> {
   if (typeof name !== "string" || name.length === 0 || name.trim() !== name) {

--- a/sdk/src/testing/agent-provider-conformance.ts
+++ b/sdk/src/testing/agent-provider-conformance.ts
@@ -5,7 +5,16 @@ import { validateAgentProvider } from "../components/agent/validate-agent-provid
 import { createAgentExecutionContext } from "./create-agent-execution-context.js"
 
 /**
- * Exercises the provider-neutral call boundary without a test-runner dependency.
+ * Exercises the provider-neutral Agent call boundary without a test-runner
+ * dependency.
+ *
+ * The check runs one request containing an initial prompt and FollowUp, requires
+ * a string response, then verifies that a pre-cancelled context rejects with the
+ * exact AbortSignal reason. A real provider may perform external work during the
+ * first call; supply isolated credentials and infrastructure in integration
+ * tests. The promise resolves only when every assertion passes.
+ *
+ * @param provider Provider instance to validate and exercise.
  */
 export async function agentProviderConformance(provider: AgentProvider): Promise<void> {
   const validatedProvider = validateAgentProvider(provider)

--- a/sdk/src/testing/create-agent-execution-context.ts
+++ b/sdk/src/testing/create-agent-execution-context.ts
@@ -11,6 +11,12 @@ const NOOP_EVENTS: AmlEventSubscriber = Object.freeze({
  *
  * Narrow overrides keep provider-specific clients local while one SDK fixture
  * absorbs additions to the portable Agent execution contract.
+ *
+ * Omitted fields receive a no-op event subscriber, a never-aborted signal, no
+ * Sandbox, and trace ids of `"agent-test"`. The returned context and trace
+ * identity are frozen; supplied provider-owned objects are not deep-cloned.
+ *
+ * @param overrides Portable context fields needed by the test under construction.
  */
 export function createAgentExecutionContext(
   overrides: Partial<AgentExecutionContext> = {}

--- a/sdk/src/testing/deterministic-agent-provider.ts
+++ b/sdk/src/testing/deterministic-agent-provider.ts
@@ -18,6 +18,11 @@ export class DeterministicAgentProvider implements AgentProvider {
     callIndex: number
   ) => AgentResponse | PromiseLike<AgentResponse>
   readonly #supportsSandbox: ((sandbox: SandboxSession) => boolean) | undefined
+  /**
+   * Provider identifier recorded in Agent requests and traces.
+   *
+   * Defaults to `"deterministic"` and must be non-empty and already trimmed.
+   */
   readonly name: string
 
   /**
@@ -25,12 +30,24 @@ export class DeterministicAgentProvider implements AgentProvider {
    */
   constructor(
     options: {
+      /** Provider identifier; defaults to `"deterministic"`. */
       readonly name?: string
+      /**
+       * Response strategy invoked after the call is recorded.
+       *
+       * Defaults to returning the request prompt as response text. `callIndex`
+       * is zero-based and follows provider execution order.
+       */
       readonly respond?: (
         request: AgentRequest,
         context: AgentExecutionContext,
         callIndex: number
       ) => AgentResponse | PromiseLike<AgentResponse>
+      /**
+       * Sandbox compatibility predicate used by `supportsSandbox()`.
+       *
+       * Omit to report every Sandbox as unsupported.
+       */
       readonly supportsSandbox?: (sandbox: SandboxSession) => boolean
     } = {}
   ) {
@@ -53,7 +70,10 @@ export class DeterministicAgentProvider implements AgentProvider {
    * Returns recorded calls in provider execution order for behavioral assertions.
    */
   get calls(): readonly Readonly<{
+    /** Execution services and cancellation state supplied for this call. */
     context: AgentExecutionContext
+
+    /** Immutable provider-neutral Agent request received by the test double. */
     request: AgentRequest
   }>[] {
     return this.#calls

--- a/sdk/src/testing/deterministic-sandbox-provider.ts
+++ b/sdk/src/testing/deterministic-sandbox-provider.ts
@@ -10,24 +10,73 @@ import type {
  * Default opaque handle exposed by the deterministic Sandbox fixture.
  */
 export interface DeterministicSandboxHandle {
+  /** Zero-based acquisition order for this fixture instance. */
   readonly acquisition: number
+
+  /** Stable default-handle discriminant. */
   readonly kind: "deterministic-sandbox"
+
+  /** Exact acquisition request recorded by the provider. */
   readonly request: SandboxAcquireRequest
+}
+
+/** Lease identity passed to deterministic Sandbox release hooks. */
+interface DeterministicSandboxLeaseIdentity<Handle> {
+  /** Handle returned by the configured creation strategy. */
+  readonly handle: Handle
+
+  /** Deterministic lease id in `<provider-name>-<one-based-index>` form. */
+  readonly id: string
 }
 
 /**
  * Configuration hooks for deterministic acquisition and release behavior.
  */
 export interface DeterministicSandboxProviderOptions<Handle> {
+  /**
+   * Creates the provider-specific handle for an acquisition.
+   *
+   * Defaults to a {@link DeterministicSandboxHandle}. `acquisition` is the
+   * zero-based call index.
+   */
   readonly createHandle?: (request: SandboxAcquireRequest, acquisition: number) => Handle | PromiseLike<Handle>
+
+  /**
+   * Implements deterministic buffered command execution.
+   *
+   * Defaults to exit code `0`, empty stderr, and stdout containing the command
+   * and arguments joined by spaces.
+   */
   readonly exec?: (
     command: string,
     args: readonly string[],
     request: SandboxAcquireRequest,
     options: Readonly<SandboxExecOptions>
   ) => SandboxExecResult | PromiseLike<SandboxExecResult>
+
+  /**
+   * Provider identifier used in lease ids.
+   *
+   * Defaults to `"deterministic-sandbox"` and must be non-empty and trimmed.
+   */
   readonly name?: string
-  readonly release?: (lease: Readonly<{ handle: Handle; id: string }>, acquisition: number) => void | PromiseLike<void>
+
+  /**
+   * Hook invoked when a lease is released, after its id is recorded.
+   *
+   * Defaults to a no-op. `acquisition` is the zero-based acquisition index.
+   */
+  readonly release?: (
+    lease: Readonly<DeterministicSandboxLeaseIdentity<Handle>>,
+    acquisition: number
+  ) => void | PromiseLike<void>
+
+  /**
+   * Implements deterministic streaming process execution.
+   *
+   * Defaults to an already-completed process whose stdout contains the command
+   * and arguments, stderr is empty, and exit code is `0`.
+   */
   readonly spawn?: (
     command: string,
     args: readonly string[],
@@ -43,9 +92,13 @@ export class DeterministicSandboxProvider<Handle = DeterministicSandboxHandle> i
   readonly #acquisitions: SandboxAcquireRequest[] = []
   readonly #createHandle: (request: SandboxAcquireRequest, acquisition: number) => Handle | PromiseLike<Handle>
   readonly #exec: NonNullable<DeterministicSandboxProviderOptions<Handle>["exec"]>
-  readonly #release: (lease: Readonly<{ handle: Handle; id: string }>, acquisition: number) => void | PromiseLike<void>
+  readonly #release: (
+    lease: Readonly<DeterministicSandboxLeaseIdentity<Handle>>,
+    acquisition: number
+  ) => void | PromiseLike<void>
   readonly #releases: string[] = []
   readonly #spawn: NonNullable<DeterministicSandboxProviderOptions<Handle>["spawn"]>
+  /** Stable provider identifier configured for this fixture. */
   readonly name: string
 
   /**

--- a/sdk/src/testing/deterministic-workspace-provider.ts
+++ b/sdk/src/testing/deterministic-workspace-provider.ts
@@ -9,32 +9,72 @@ import { WorkspaceConflictError } from "../components/workspace/workspace-confli
  * Default opaque handle exposed by the deterministic Workspace fixture.
  */
 export interface DeterministicWorkspaceHandle {
+  /** Zero-based acquisition order for this fixture instance. */
   readonly acquisition: number
+
+  /** Stable default-handle discriminant. */
   readonly kind: "deterministic-workspace"
+
+  /** Exact acquisition request recorded by the provider. */
   readonly request: WorkspaceAcquireRequest
+}
+
+/** Lease identity passed to deterministic Workspace lifecycle hooks. */
+interface DeterministicWorkspaceLeaseIdentity<Handle> {
+  /** Materialization directory exposed by the lease. */
+  readonly directory: string
+
+  /** Handle returned by the configured creation strategy. */
+  readonly handle: Handle
+
+  /** Deterministic lease id in `<provider-name>-<one-based-index>` form. */
+  readonly id: string
 }
 
 /**
  * Configuration hooks for deterministic materialization and persistence.
  */
 export interface DeterministicWorkspaceProviderOptions<Handle> {
+  /**
+   * Creates the provider-specific handle for an acquisition.
+   *
+   * Defaults to a {@link DeterministicWorkspaceHandle}. `acquisition` is the
+   * zero-based call index.
+   */
   readonly createHandle?: (request: WorkspaceAcquireRequest, acquisition: number) => Handle | PromiseLike<Handle>
+
+  /**
+   * Materialization directory or a per-acquisition directory strategy.
+   *
+   * Defaults to `"/deterministic-workspace"`.
+   */
   readonly directory?: string | ((request: WorkspaceAcquireRequest, acquisition: number) => string)
+
+  /**
+   * Provider identifier used in lease ids.
+   *
+   * Defaults to `"deterministic-workspace"` and must be non-empty and trimmed.
+   */
   readonly name?: string
+
+  /**
+   * Hook invoked during lease release before writer ownership is cleared.
+   *
+   * Defaults to a no-op. Ownership is still cleared when this hook rejects so
+   * later tests cannot deadlock on fixture state.
+   */
   readonly release?: (
-    lease: Readonly<{
-      directory: string
-      handle: Handle
-      id: string
-    }>,
+    lease: Readonly<DeterministicWorkspaceLeaseIdentity<Handle>>,
     acquisition: number
   ) => void | PromiseLike<void>
+
+  /**
+   * Hook invoked when AML asks the lease to persist its materialization.
+   *
+   * Defaults to a no-op and runs after the lease id is recorded in `saves`.
+   */
   readonly save?: (
-    lease: Readonly<{
-      directory: string
-      handle: Handle
-      id: string
-    }>,
+    lease: Readonly<DeterministicWorkspaceLeaseIdentity<Handle>>,
     acquisition: number
   ) => void | PromiseLike<void>
 }
@@ -53,6 +93,7 @@ export class DeterministicWorkspaceProvider<
   readonly #releases: string[] = []
   readonly #save: NonNullable<DeterministicWorkspaceProviderOptions<Handle>["save"]>
   readonly #saves: string[] = []
+  /** Stable provider identifier configured for this fixture. */
   readonly name: string
 
   /**

--- a/sdk/src/testing/in-memory-workspace-storage-adapter.ts
+++ b/sdk/src/testing/in-memory-workspace-storage-adapter.ts
@@ -13,9 +13,15 @@ interface StoredObject {
   readonly version: WorkspaceStorageVersion
 }
 
+/** One storage call recorded by {@link InMemoryWorkspaceStorageAdapter}. */
 export interface WorkspaceStorageOperation {
+  /** Storage method that was invoked. */
   readonly kind: "delete" | "list" | "read" | "release" | "write"
+
+  /** Object path or list prefix; omitted for lease release operations. */
   readonly path?: string
+
+  /** Logical Workspace id whose namespace received the operation. */
   readonly workspaceId: string
 }
 
@@ -27,21 +33,40 @@ export class InMemoryWorkspaceStorageAdapter implements WorkspaceStorageAdapter 
   readonly #objects = new Map<string, Map<string, StoredObject>>()
   readonly #operations: WorkspaceStorageOperation[] = []
   #version = 0
+  /** Stable adapter name included in persistent Workspace provider references. */
   readonly name = "memory-workspace-storage"
 
+  /**
+   * Chronological, live view of storage calls made through this adapter.
+   *
+   * Entries are appended before each operation mutates in-memory state.
+   */
   get operations(): readonly Readonly<WorkspaceStorageOperation>[] {
     return this.#operations
   }
 
+  /** Returns sorted object paths currently stored for one logical Workspace. */
   keys(workspaceId: string): readonly string[] {
     return [...(this.#objects.get(workspaceId)?.keys() ?? [])].sort()
   }
 
+  /**
+   * Decodes one stored object as UTF-8 text for assertions.
+   *
+   * Returns `undefined` when the Workspace or object path does not exist.
+   */
   async text(workspaceId: string, objectPath: string): Promise<string | undefined> {
     const object = this.#objects.get(workspaceId)?.get(objectPath)
     return object === undefined ? undefined : Buffer.from(object.body).toString("utf8")
   }
 
+  /**
+   * Opens an in-memory object namespace and optionally claims its exclusive lock.
+   *
+   * Competing locked acquisitions of the same id reject with
+   * {@link WorkspaceConflictError}. The returned lease supports conditional
+   * writes and releases ownership idempotently.
+   */
   async acquire(request: WorkspaceStorageAcquireRequest): Promise<WorkspaceStorageLease> {
     request.signal.throwIfAborted()
 

--- a/sdk/src/testing/sandbox-provider-conformance.ts
+++ b/sdk/src/testing/sandbox-provider-conformance.ts
@@ -7,6 +7,14 @@ import {
 
 /**
  * Exercises one complete provider-neutral Sandbox lease lifecycle.
+ *
+ * The check acquires a read-only Sandbox with logical root and cwd `"."`,
+ * validates the returned lease and runtime metadata, and releases the resource
+ * even when validation fails after a release function becomes available. It
+ * does not execute commands. A real provider may create billable external
+ * infrastructure; use an isolated test account and cleanup policy.
+ *
+ * @param provider Provider instance to validate and exercise.
  */
 export async function sandboxProviderConformance(provider: SandboxProvider): Promise<void> {
   const validatedProvider = validateSandboxProvider(provider)

--- a/sdk/src/testing/workspace-provider-conformance.ts
+++ b/sdk/src/testing/workspace-provider-conformance.ts
@@ -9,6 +9,15 @@ import { WorkspaceConflictError } from "../components/workspace/workspace-confli
 
 /**
  * Exercises exclusive acquisition, persistence, release, and restoration.
+ *
+ * The check acquires the fixed logical id `"conformance-workspace"`, requires a
+ * competing writer to fail with {@link WorkspaceConflictError}, saves and
+ * releases the first lease, then reacquires, saves, and releases it again. It
+ * preserves cleanup failures rather than abandoning acquired resources. A real
+ * provider may create durable or billable state; run against an isolated test
+ * namespace that may safely retain this id.
+ *
+ * @param provider Provider instance to validate and exercise.
  */
 export async function workspaceProviderConformance(provider: WorkspaceProvider): Promise<void> {
   const validated = validateWorkspaceProvider(provider)

--- a/sdk/src/workspace-persistence/workspace-index.ts
+++ b/sdk/src/workspace-persistence/workspace-index.ts
@@ -1,15 +1,30 @@
+/** Durable representation used for each Workspace revision artifact. */
 export type WorkspacePersistenceFormat = "archive" | "folder"
 
+/** One immutable revision recorded in the durable Workspace index. */
 export interface WorkspaceRevision {
+  /** Canonical ISO-8601 publication timestamp. */
   readonly createdAt: string
+
+  /** Representation used by this revision, independent of later defaults. */
   readonly format: WorkspacePersistenceFormat
+
+  /** Non-empty immutable revision identifier. */
   readonly id: string
+
+  /** Canonical storage path derived from `id` and `format`. */
   readonly path: string
 }
 
+/** Versioned durable metadata selecting and retaining Workspace revisions. */
 export interface WorkspaceIndex {
+  /** Revision ID materialized by the `"current"` selector. */
   readonly current: string
+
+  /** Retained revisions, newest first, including `current`. */
   readonly revisions: readonly WorkspaceRevision[]
+
+  /** On-storage index schema version. */
   readonly version: 1
 }
 

--- a/sdk/src/workspace-persistence/workspace-persistence.ts
+++ b/sdk/src/workspace-persistence/workspace-persistence.ts
@@ -36,28 +36,81 @@ const DEFAULT_MAX_ENTRIES = 100_000
 const DEFAULT_MAX_EXTRACTED_BYTES = 1024 * 1024 * 1024
 const MAX_INDEX_BYTES = 4 * 1024 * 1024
 
+/** Configuration for AML's revision protocol over a storage adapter. */
 export interface WorkspacePersistenceOptions<StorageHandle = unknown> {
+  /**
+   * Representation used for newly published revisions.
+   *
+   * Defaults to `"archive"`. Existing revisions retain and restore with the
+   * format recorded in their index entry.
+   */
   readonly format?: WorkspacePersistenceFormat
+
+  /**
+   * Maximum compressed archive bytes accepted during save or restore.
+   *
+   * Defaults to 256 MiB and must be a positive safe integer.
+   */
   readonly maxArchiveBytes?: number
+
+  /**
+   * Maximum selected filesystem entries in one snapshot.
+   *
+   * Defaults to `100000` and must be a positive safe integer.
+   */
   readonly maxEntries?: number
+
+  /**
+   * Maximum combined uncompressed bytes in one snapshot.
+   *
+   * Defaults to 1 GiB and must be a positive safe integer.
+   */
   readonly maxExtractedBytes?: number
+
+  /** Durable storage adapter owning namespaces, locking, and object I/O. */
   readonly storage: WorkspaceStorageAdapter<StorageHandle>
+
+  /**
+   * Parent directory for per-acquisition local staging.
+   *
+   * Defaults to `os.tmpdir()` and is resolved to an absolute host path.
+   */
   readonly temporaryDirectory?: string
 }
 
+/** Opaque handle exposed by a revision-backed Workspace materialization. */
 export interface PersistentWorkspaceHandle<StorageHandle = unknown> {
+  /** Format configured for the next save from this materialization. */
   readonly format: WorkspacePersistenceFormat
+
+  /** Stable discriminant for AML's shared persistence implementation. */
   readonly kind: "persistent-workspace"
+
+  /** Revision restored into this materialization, omitted for an empty start. */
   readonly revisionId?: string
+
+  /** Opaque handle returned by the underlying storage lease. */
   readonly storage: StorageHandle
 }
 
+/** Validated persistence configuration retained by WorkspacePersistence. */
 interface ParsedWorkspacePersistenceOptions<StorageHandle> {
+  /** Archive format used for subsequent Workspace saves. */
   readonly format: WorkspacePersistenceFormat
+
+  /** Maximum compressed archive size accepted during restore. */
   readonly maxArchiveBytes: number
+
+  /** Maximum number of entries accepted from one archive. */
   readonly maxEntries: number
+
+  /** Maximum total uncompressed bytes accepted during extraction. */
   readonly maxExtractedBytes: number
+
+  /** Durable object and writer-authority adapter. */
   readonly storage: WorkspaceStorageAdapter<StorageHandle>
+
+  /** Absolute host directory under which materializations are created. */
   readonly temporaryDirectory: string
 }
 
@@ -69,6 +122,11 @@ interface RestoredWorkspace {
 
 /**
  * Creates a revision-backed Workspace provider over one small storage adapter.
+ *
+ * Configuration is validated immediately without acquiring storage. The
+ * returned immutable provider owns local staging, revision restore, conditional
+ * index publication, retention, and cleanup; the adapter owns durable object
+ * semantics and writer authority.
  */
 export function createPersistentWorkspaceProvider<StorageHandle = unknown>(
   options: WorkspacePersistenceOptions<StorageHandle>
@@ -83,13 +141,21 @@ export class WorkspacePersistence<StorageHandle = unknown> implements WorkspaceP
   PersistentWorkspaceHandle<StorageHandle>
 > {
   readonly #options: Readonly<ParsedWorkspacePersistenceOptions<StorageHandle>>
+  /** Provider name inherited from the configured storage adapter. */
   readonly name: string
 
+  /** Validates and captures persistence limits and the storage adapter. */
   constructor(options: WorkspacePersistenceOptions<StorageHandle> | ParsedWorkspacePersistenceOptions<StorageHandle>) {
     this.#options = parseWorkspacePersistenceOptions(options)
     this.name = this.#options.storage.name
   }
 
+  /**
+   * Acquires storage authority, creates a unique local materialization, and
+   * restores the selected revision.
+   *
+   * Any failure removes partial local state and releases the storage lease.
+   */
   async acquire(request: WorkspaceAcquireRequest): Promise<WorkspaceLease<PersistentWorkspaceHandle<StorageHandle>>> {
     request.signal.throwIfAborted()
     const storage = await this.#options.storage.acquire({

--- a/sdk/src/workspace-persistence/workspace-storage-adapter.ts
+++ b/sdk/src/workspace-persistence/workspace-storage-adapter.ts
@@ -1,32 +1,65 @@
+/** Body accepted by portable Workspace storage writes. */
 export type WorkspaceStorageBody = AsyncIterable<Uint8Array> | Uint8Array | string
 
+/** Opaque storage revision token used for conditional publication. */
 export interface WorkspaceStorageVersion {
+  /** Provider-owned version value; consumers compare it only by exact value. */
   readonly value: string
 }
 
+/** One readable durable object and the version observed with it. */
 export interface WorkspaceStorageObject {
+  /** Async byte stream consumed once by the persistence layer. */
   readonly body: AsyncIterable<Uint8Array>
+
+  /** Version token captured atomically with the object read. */
   readonly version: WorkspaceStorageVersion
 }
 
+/** One storage object path returned from a prefix listing. */
 export interface WorkspaceStorageEntry {
+  /** Normalized relative path within the acquired Workspace namespace. */
   readonly path: string
 }
 
+/** Precondition applied atomically to a storage write. */
 export type WorkspaceStorageWriteCondition =
-  | { readonly kind: "absent" }
-  | { readonly kind: "version"; readonly version: WorkspaceStorageVersion }
+  | {
+      /** Requires the destination not to exist. */
+      readonly kind: "absent"
+    }
+  | {
+      /** Requires the destination to match `version`. */
+      readonly kind: "version"
 
+      /** Opaque version previously returned by `read` or `write`. */
+      readonly version: WorkspaceStorageVersion
+    }
+
+/** Optional metadata and atomicity controls for one storage write. */
 export interface WorkspaceStorageWriteOptions {
+  /** Write precondition; omission permits an unconditional replacement. */
   readonly condition?: WorkspaceStorageWriteCondition
+
+  /** Known body byte length supplied to transports that require it. */
   readonly contentLength?: number
+
+  /** MIME type stored with the object when supported by the backend. */
   readonly contentType?: string
 }
 
+/** Namespace and locking request passed to a Workspace storage adapter. */
 export interface WorkspaceStorageAcquireRequest {
+  /** Unique identity of the AML evaluation acquiring storage authority. */
   readonly evaluationId: string
+
+  /** Non-empty normalized durable Workspace identity. */
   readonly id: string
+
+  /** Whether the adapter must acquire exclusive writer authority. */
   readonly lock: boolean
+
+  /** Evaluation signal covering acquisition and storage operations. */
   readonly signal: AbortSignal
 }
 
@@ -55,12 +88,26 @@ export function workspaceStorageSegment(workspaceId: string): string {
  * Exclusive provider-native access to one Workspace storage namespace.
  */
 export interface WorkspaceStorageLease<Handle = unknown> {
+  /** Opaque provider handle exposed through the persistent Workspace lease. */
   readonly handle: Handle
 
+  /** Deletes the listed normalized object paths; an empty list is a no-op. */
   delete(paths: readonly string[]): Promise<void>
+
+  /** Lists normalized object paths beneath a normalized prefix. */
   list(prefix: string): Promise<readonly WorkspaceStorageEntry[]>
+
+  /** Reads one object or returns `undefined` when it does not exist. */
   read(path: string): Promise<WorkspaceStorageObject | undefined>
+
+  /** Releases writer authority and lease-owned storage resources; repeat-safe. */
   release(): Promise<void>
+
+  /**
+   * Writes one complete object and returns its new opaque version.
+   *
+   * Conditional failure must reject without modifying the destination.
+   */
   write(
     path: string,
     body: WorkspaceStorageBody,
@@ -72,7 +119,14 @@ export interface WorkspaceStorageLease<Handle = unknown> {
  * Minimal durable transport implemented by S3 and filesystem providers.
  */
 export interface WorkspaceStorageAdapter<Handle = unknown> {
+  /** Non-empty normalized provider name exposed by WorkspacePersistence. */
   readonly name: string
 
+  /**
+   * Acquires one Workspace storage namespace and optional writer authority.
+   *
+   * A pre-aborted signal starts no work. Healthy competing writers reject with
+   * `WorkspaceConflictError`; other storage failures retain their own identity.
+   */
   acquire(request: WorkspaceStorageAcquireRequest): Promise<WorkspaceStorageLease<Handle>>
 }

--- a/sdk/tests/public-api-documentation.test.ts
+++ b/sdk/tests/public-api-documentation.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import ts from "@typescript/typescript6"
+import { describe, expect, it } from "vitest"
+
+import { PublicApiDocumentationChecker } from "../scripts/check-public-api-docs.js"
+
+describe("PublicApiDocumentationChecker", () => {
+  it("rejects undocumented local shapes reached through references and inheritance", async () => {
+    const issues = await checkFixture(`
+/** Public configuration. */
+export interface PublicConfig extends UndocumentedBase {
+  /** Nested configuration. */
+  nested?: UndocumentedNested
+}
+
+interface UndocumentedBase {
+  inherited?: number
+}
+
+interface UndocumentedNested {
+  value?: string
+}
+`)
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: expect.stringContaining("(UndocumentedBase) is missing documentation") }),
+        expect.objectContaining({ label: expect.stringContaining("(UndocumentedBase).inherited") }),
+        expect.objectContaining({ label: expect.stringContaining("(UndocumentedNested) is missing documentation") }),
+        expect.objectContaining({ label: expect.stringContaining("(UndocumentedNested).value") }),
+      ])
+    )
+  })
+
+  it("accepts documented local shapes reached through references and inheritance", async () => {
+    const issues = await checkFixture(`
+/** Shared configuration. */
+interface SharedConfig {
+  /** Shared value. */
+  shared?: number
+}
+
+/** Nested configuration. */
+interface NestedConfig {
+  /** Nested value. */
+  value?: string
+}
+
+/** Public configuration. */
+export interface PublicConfig extends SharedConfig {
+  /** Nested configuration. */
+  nested?: NestedConfig
+}
+`)
+
+    expect(issues).toEqual([])
+  })
+})
+
+async function checkFixture(source: string) {
+  const directory = await mkdtemp(join(tmpdir(), "aml-public-api-docs-"))
+  const entrypoint = join(directory, "index.ts")
+
+  try {
+    await writeFile(entrypoint, source)
+    const program = ts.createProgram({
+      options: { module: ts.ModuleKind.ESNext, strict: true, target: ts.ScriptTarget.ES2022 },
+      rootNames: [entrypoint],
+    })
+
+    return new PublicApiDocumentationChecker(program, directory).check([entrypoint])
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+}


### PR DESCRIPTION
## Description

Document AML’s installed TypeScript surface so primitives, providers, exported types, props, defaults, constraints, lifecycle behavior, and security boundaries are discoverable in IDEs and by agents.

## What changed?

- Added detailed JSDoc across the SDK, testing helpers, and bundled Agent, Sandbox, and Workspace providers.
- Replaced OpenCode’s inherited config alias with an AML-owned documented shape kept in exact type parity with the pinned SDK.
- Added a recursive public-documentation gate that follows local type references and inheritance, with positive and negative fixtures.

## Verification

- Inspected generated declarations to confirm nested JSDoc survives package emission.
- Exercised the documentation gate against undocumented and fully documented nested fixture graphs.
- Verified the OpenCode configuration remains exactly type-compatible with the bundled SDK.
- Audited the binary-only CLI help and command reference; no CLI source change was required.
- Validated packed SDK, CLI, Agent, Sandbox, and Workspace packages.

> Public contracts speak
> Editors reveal each choice
> Drift breaks at the gate
