### PR TITLE
ci: activate trusted singular code review

### DIFF
--- a/.github/workflows/singular-code-review.yml
+++ b/.github/workflows/singular-code-review.yml
@@ -33,6 +33,7 @@ jobs:
       cancel-in-progress: true
     uses: we-are-singular/singular-code-review-agent/.github/workflows/review.yml@main
     with:
+      runner: singular-code-review
       pr_number: ${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.pr_number }}
       trigger_comment_id: ${{ github.event.comment.id || '' }}
     secrets:

--- a/.github/workflows/singular-code-review.yml
+++ b/.github/workflows/singular-code-review.yml
@@ -1,0 +1,41 @@
+name: Singular Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    if: >-
+      github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@singular-code-review'))
+    concurrency:
+      group: singular-code-review-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.pr_number }}
+      cancel-in-progress: true
+    uses: we-are-singular/singular-code-review-agent/.github/workflows/review.yml@main
+    with:
+      pr_number: ${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.pr_number }}
+      trigger_comment_id: ${{ github.event.comment.id || '' }}
+    secrets:
+      SINGULAR_CODE_REVIEW_PRIVATE_KEY: ${{ secrets.SINGULAR_CODE_REVIEW_PRIVATE_KEY }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}


### PR DESCRIPTION
## Description

Activate Singular Code Review for AML using the canonical GitHub-hosted caller.

Depends on https://github.com/we-are-singular/singular-code-review-agent/pull/14 so the reusable reviewer disables repository-owned OpenCode configuration before this workflow becomes active.

## What changed?

- Added automatic review for non-draft same-repository PRs.
- Kept public fork heads out of automatic review.
- Limited comment-triggered reviews to owners, organization members, and collaborators.
- Used the reusable workflow's GitHub-hosted runner and dependency-install defaults.

## Verification

- Matched the caller byte-for-byte against the canonical SCR workflow.
- Checked fork, trusted-comment, private-runner, and dependency-install boundaries.
- Verified AML's live external-contributor approval policy remains enabled.

> AML checks its form  
> Trusted changes meet review  
> Forks await consent
