### PR TITLE
feat(sandbox): sync Docker Hub overview

### DIFF
--- a/images/sandbox/DOCKERHUB.md
+++ b/images/sandbox/DOCKERHUB.md
@@ -1,0 +1,109 @@
+# AML Agent Sandbox
+
+Run [AML](https://agent-markup-language.com/) workflows and ACP coding agents in ready-to-use Debian containers. The images include AML, the selected Agent runtime, Node.js, Python, Git, and the command-line tools agents commonly need.
+
+```sh
+docker pull wearesingular/aml-agent-sandbox:latest
+```
+
+## Choose an image
+
+Use `latest` when your application can select different Agents. Use an Agent-specific tag when every workflow uses the same Agent and you want a smaller image.
+
+| Image    | Moving tag         | Versioned tag           |
+| -------- | ------------------ | ----------------------- |
+| Full     | `latest` or `full` | `X.Y.Z` or `X.Y.Z-full` |
+| Codex    | `codex`            | `X.Y.Z-codex`           |
+| Copilot  | `copilot`          | `X.Y.Z-copilot`         |
+| GLM      | `glm`              | `X.Y.Z-glm`             |
+| OpenCode | `opencode`         | `X.Y.Z-opencode`        |
+| Pi       | `pi`               | `X.Y.Z-pi`              |
+
+Moving tags follow the newest stable image in their lane. Use a versioned tag or digest when the deployment must stay on one image.
+
+Every variant contains the same AML and system runtime. Each Agent-specific variant is built directly from the shared base plus its selected Agent.
+
+## Use with AML
+
+The Docker Sandbox uses the full image by default:
+
+```ts
+import { dockerSandbox } from "@aml-jsx/sdk"
+
+const sandbox = dockerSandbox()
+```
+
+Image selection does not select the Agent. Configure matching Agent and Sandbox providers together. This example runs OpenCode with the smaller OpenCode image:
+
+```ts
+import { AmlRuntime, dockerSandbox, opencodeAgent } from "@aml-jsx/sdk"
+
+const apiKey = process.env.OPENCODE_API_KEY
+if (!apiKey) throw new Error("OPENCODE_API_KEY is required")
+
+const runtime = new AmlRuntime({
+  agentProvider: opencodeAgent({
+    model: "opencode-go/deepseek-v4-flash",
+    env: { OPENCODE_API_KEY: apiKey },
+  }),
+  sandboxProvider: dockerSandbox({
+    image: "wearesingular/aml-agent-sandbox:opencode",
+  }),
+})
+```
+
+An OpenCode image does not contain Codex, Copilot, GLM, or Pi. Pairing it with another Agent provider fails because that Agent's executable is absent.
+
+## What's inside
+
+Every image includes:
+
+- the `aml` CLI and `@aml-jsx/sdk`;
+- Node.js 26 and npm;
+- Python 3, pip, and `venv`;
+- Git, OpenSSH, Bash, curl, CA certificates, jq, ripgrep, patch, and common shell tools;
+- a Debian Bookworm/glibc runtime;
+- a non-root `aml` user with writable `/home/aml`, `/tmp`, and `/workspace`.
+
+The image contains no credentials, Agent login state, project dependencies, browsers, cloud CLIs, Docker daemon, compilers, or broad language toolchains.
+
+Inspect a variant directly:
+
+```sh
+docker run --rm wearesingular/aml-agent-sandbox:opencode opencode --version
+docker run --rm wearesingular/aml-agent-sandbox:opencode aml --version
+```
+
+## Add project dependencies
+
+Build on the smallest variant that contains your Agent. This example adds SQLite to OpenCode:
+
+```dockerfile
+FROM wearesingular/aml-agent-sandbox:opencode
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+USER aml
+WORKDIR /workspace
+```
+
+Add project tools to a derived image instead of reinstalling them whenever a Sandbox starts.
+
+## Credentials and security
+
+Pass model credentials when the Sandbox starts. Do not bake API keys, Agent homes, repository credentials, or application state into an image layer.
+
+The images run as a non-root user, but the deployment still owns network policy, Linux capabilities, seccomp/AppArmor, resource limits, secret injection, and Docker daemon security. Pin trusted digests and apply a container policy appropriate for the code your Agent can execute.
+
+## Learn more
+
+- [Image guide and complete tag reference](https://agent-markup-language.com/docs/sandbox-images/)
+- [Run AML in a Sandbox image](https://agent-markup-language.com/docs/cookbook/sandbox-image/)
+- [Docker Sandbox provider](https://agent-markup-language.com/docs/providers/sandboxes/docker/)
+- [Image changelog](https://agent-markup-language.com/docs/reference/changelog/sandbox/)
+- [Source and issues](https://github.com/we-are-singular/aml)
+
+AML image source is MIT licensed. Bundled software keeps its own license.

--- a/images/sandbox/README.md
+++ b/images/sandbox/README.md
@@ -154,7 +154,9 @@ Stable image releases run locally, not in GitHub Actions. Start from a clean `ma
 npm run release:sandbox
 ```
 
-The command checks that Docker Buildx and Cosign are installed. Docker Hub's browser login then uses a temporary Docker configuration while the caller's Buildx configuration and selected builder remain available. The temporary credentials are deleted when the command exits. Release It prompts for the version, builds and checks every variant, and creates one `sandbox-vX.Y.Z` release commit and tag. Publication pushes the immutable variant tags with SBOM and provenance attestations, runs each Agent's real Docker smoke against the exact pushed digest, signs every digest, and only then updates the moving tags. The active `gh` account authorizes the source tag's GitHub Release.
+The command checks that Docker Buildx and Cosign are installed. Docker Hub's browser login then uses a temporary Docker configuration while the caller's Buildx configuration and selected builder remain available. The temporary credentials are deleted when the command exits. Release It prompts for the version, builds and checks every variant, and creates one `sandbox-vX.Y.Z` release commit and tag. Publication pushes the immutable variant tags with SBOM and provenance attestations, runs each Agent's real Docker smoke against the exact pushed digest, signs every digest, and only then updates the moving tags and publishes [`DOCKERHUB.md`](./DOCKERHUB.md) as the Docker Hub repository overview. The active `gh` account authorizes the source tag's GitHub Release.
+
+Docker Hub's metadata API requires a username and personal access token rather than the browser-based registry login used for image publication. Authenticate once in the caller's normal Docker configuration with `docker login --username <username>`, using a read/write personal access token as the password. The release reuses that credential only for the overview update while keeping image publication credentials temporary. To resynchronize only the overview, run `npm run sync:description --prefix images/sandbox`.
 
 Before authentication, the release inspects the selected Buildx driver. An existing attestation-capable builder is used as configured. When the selected builder uses the incompatible `docker` driver, the release creates or reuses the `aml-agent-sandbox-publisher` `docker-container` builder for its child processes without changing the caller's global builder selection.
 
@@ -168,7 +170,7 @@ If image publication fails after Release It creates the release commit and tag, 
 npm run release:sandbox -- --recover
 ```
 
-Recovery requires `HEAD` to have the `sandbox-vX.Y.Z` tag matching this package's version. It safely reruns image publication and creates the GitHub Release if the first attempt did not reach that step.
+Recovery requires `HEAD` to have the `sandbox-vX.Y.Z` tag matching this package's version and the same read/write Docker Hub personal access token used by a normal release. It safely reruns image publication and creates the GitHub Release if the first attempt did not reach that step.
 
 If every immutable image and smoke completed and the release failed only during Cosign signing, resume from the pushed digests without rebuilding or rerunning smoke:
 

--- a/images/sandbox/package.json
+++ b/images/sandbox/package.json
@@ -16,6 +16,7 @@
     "check:all": "node scripts/check.mjs --all",
     "release": "node scripts/release.mjs",
     "release:check": "node --test scripts/*.test.mjs && npm audit --omit=dev && npm run build:all && npm run check:all",
+    "sync:description": "node scripts/sync-description.mjs",
     "update:aml": "npm install --save-exact --ignore-scripts @aml-jsx/cli@latest @aml-jsx/sdk@latest",
     "verify:release": "node scripts/verify-release.mjs"
   },

--- a/images/sandbox/scripts/release.mjs
+++ b/images/sandbox/scripts/release.mjs
@@ -46,6 +46,8 @@ function release() {
 
   try {
     runOrThrow("node", ["scripts/publish.mjs", "--check"], releaseEnvironment)
+    // Overview sync uses the caller's metadata PAT, not the isolated image publication config.
+    runOrThrow("node", ["scripts/sync-description.mjs", "--check"], process.env)
     prepareBuildx(releaseEnvironment)
 
     // Release It uses the active CLI token for the source tag's GitHub Release.
@@ -60,13 +62,24 @@ function release() {
         releaseEnvironment
       )
       ensureGithubRelease(recoveryVersion, releaseEnvironment)
+      syncDescription()
       process.stdout.write(`Recovered AML Agent Sandbox ${recoveryVersion}\n`)
       return 0
     }
 
-    return run("release-it", releaseArguments, releaseEnvironment)
+    const status = run("release-it", releaseArguments, releaseEnvironment)
+    if (status === 0) syncDescription()
+    return status
   } finally {
     rmSync(dockerConfig, { recursive: true, force: true })
+  }
+}
+
+function syncDescription() {
+  if (run("node", ["scripts/sync-description.mjs"], process.env) !== 0) {
+    process.stderr.write(
+      "Warning: image publication succeeded, but the Docker Hub overview did not sync. Run npm run sync:description --prefix images/sandbox to retry.\n"
+    )
   }
 }
 

--- a/images/sandbox/scripts/sync-description.mjs
+++ b/images/sandbox/scripts/sync-description.mjs
@@ -1,0 +1,114 @@
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join, resolve } from "node:path"
+import process from "node:process"
+import { pathToFileURL } from "node:url"
+
+const dockerHubRepository = "wearesingular/aml-agent-sandbox"
+const dockerHubServer = "https://index.docker.io/v1/"
+
+async function main() {
+  const [option] = process.argv.slice(2)
+  if (option !== undefined && option !== "--check") {
+    throw new Error(`Unknown option ${option}`)
+  }
+
+  const description = readFileSync(new URL("../DOCKERHUB.md", import.meta.url), "utf8")
+  if (Buffer.byteLength(description) > 25_000) {
+    throw new Error("Docker Hub repository overview exceeds its 25,000-byte limit")
+  }
+
+  const credential = readDockerCredential(process.env)
+  const token = await authenticate(credential)
+  const [namespace, repository] = dockerHubRepository.split("/")
+  const repositoryUrl = `https://hub.docker.com/v2/namespaces/${namespace}/repositories/${repository}`
+
+  if (option === "--check") {
+    const response = await fetch(repositoryUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) {
+      throw new Error(`Docker Hub repository access failed: ${response.status} ${response.statusText}`)
+    }
+    process.stdout.write(`Docker Hub overview access is available for ${dockerHubRepository}\n`)
+    return
+  }
+
+  const response = await fetch(repositoryUrl, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ full_description: description }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Docker Hub rejected the repository overview update: ${response.status} ${response.statusText}`)
+  }
+
+  const repositoryInfo = await response.json()
+  if (repositoryInfo.full_description !== description) {
+    throw new Error("Docker Hub did not return the published repository overview")
+  }
+
+  process.stdout.write(`Updated Docker Hub overview for ${dockerHubRepository}\n`)
+}
+
+function readDockerCredential(environment) {
+  const configDirectory = environment.DOCKER_CONFIG ?? join(homedir(), ".docker")
+  const config = JSON.parse(readFileSync(join(configDirectory, "config.json"), "utf8"))
+  const auth = config.auths?.[dockerHubServer]?.auth ?? config.auths?.[`${dockerHubServer}refresh-token`]?.auth
+
+  if (auth !== undefined) {
+    const decoded = Buffer.from(auth, "base64").toString("utf8")
+    const separator = decoded.indexOf(":")
+    if (separator === -1) throw new Error("Docker Hub credential has an invalid format")
+    return { username: decoded.slice(0, separator), secret: decoded.slice(separator + 1) }
+  }
+
+  const helperName = config.credHelpers?.[dockerHubServer] ?? config.credsStore
+  if (helperName === undefined) {
+    throw new Error("Docker Hub is not authenticated in the active Docker configuration")
+  }
+
+  const helper = spawnSync(`docker-credential-${helperName}`, ["get"], {
+    encoding: "utf8",
+    input: `${dockerHubServer}\n`,
+  })
+  if (helper.status !== 0) {
+    throw new Error("Could not read the existing Docker Hub credential")
+  }
+
+  const credential = JSON.parse(helper.stdout)
+  if (typeof credential.Username !== "string" || typeof credential.Secret !== "string") {
+    throw new Error("Docker credential helper returned an invalid Docker Hub credential")
+  }
+  return { username: credential.Username, secret: credential.Secret }
+}
+
+async function authenticate({ username, secret }) {
+  const response = await fetch("https://hub.docker.com/v2/auth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: username, secret }),
+  })
+  if (!response.ok) {
+    throw new Error(`Docker Hub authentication failed: ${response.status} ${response.statusText}`)
+  }
+
+  const body = await response.json()
+  const token = body.access_token ?? body.token
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("Docker Hub authentication did not return an API token")
+  }
+  return token
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Description

Give the AML Agent Sandbox a focused Docker Hub overview and keep it synchronized through the existing local publishing flow.

## What changed?

- Added a Docker Hub-specific product page covering image variants, tag selection, AML configuration, the OpenCode Go path, extension, and security.
- Added an authenticated Docker Hub metadata sync command with credential-helper support and a pre-publication access check.
- Integrated overview synchronization into normal and recovery sandbox releases while keeping Docker image publication local.

## Verification

- Confirmed the public Docker Hub overview matches the committed `DOCKERHUB.md` byte-for-byte.
- Confirmed the rendered overview includes the tag table and OpenCode Go example.
- Confirmed the preflight authenticates and reads the Docker Hub repository before entering the release flow.

> Agents choose their lane
> One clear page follows each push
> Tags point users home
