### PR TITLE
fix(sdk): use compact collision-safe tool names

### DIFF
--- a/apps/website/src/content/docs/docs/reference/runtime.mdx
+++ b/apps/website/src/content/docs/docs/reference/runtime.mdx
@@ -33,6 +33,7 @@ Choose the provider defaults and safety budgets at construction time. The input 
 | `workspaceProvider`   |               — | The evaluation may use one top-level durable `<Workspace />`.                                                                   |
 | `cwd`                 | `process.cwd()` | Local `<Include src>`, `<File src>`, and `<Skill src>` reads plus host `<Script />` execution need a controlled base directory. |
 | `system`              |               — | Every `<Agent />` should receive a shared system instruction.                                                                   |
+| `toolPrefix`          |         `"aml"` | JavaScript Tools bridged through MCP need a stable model-facing prefix; an empty string also selects `"aml"`.                   |
 | `allowedTools`        |    unrestricted | The application must allow only named Tool capabilities.                                                                        |
 | `allowedMcpServers`   |    unrestricted | The application must allow only named MCP servers.                                                                              |
 | `trace`               |               — | The application needs immutable, metadata-only-by-default trace events.                                                         |
@@ -41,6 +42,8 @@ Choose the provider defaults and safety budgets at construction time. The input 
 | `maxConcurrentAgents` |             `4` | Parallel Agent work must be bounded.                                                                                            |
 | `maxTurnsPerAgent`    |            `16` | Follow-ups and authored `<Agent />` inputs must be bounded.                                                                     |
 | `maxDepth`            |            `16` | Recursive semantic JSX needs a depth budget.                                                                                    |
+
+`toolPrefix` becomes the invocation-owned MCP server name used to qualify JavaScript Tools. For example, `toolPrefix: "review"` exposes `review_get_pull_request` in OpenCode and `review-get_pull_request` in Copilot. AML throws when the prefix conflicts with another MCP server granted to the same Agent rather than silently changing the configured name.
 
 ## Evaluation options and cancellation
 

--- a/providers/agents/copilot/tests/copilot-agent.test.tsx
+++ b/providers/agents/copilot/tests/copilot-agent.test.tsx
@@ -172,7 +172,7 @@ describe("copilotAgent()", () => {
       )
     ).rejects.toThrow('Agent "copilot"')
 
-    expect(mcpServerName).toMatch(/^tools_[0-9a-f]{12}$/u)
+    expect(mcpServerName).toBe("aml")
     expect(prompts).toHaveLength(2)
     expect(prompts[0]).toContain("<SYSTEM>\nFollow the authored system.\n</SYSTEM>")
     expect(prompts[0]).toContain(`- copilot_proof: ${mcpServerName}-copilot_proof`)

--- a/providers/agents/copilot/tests/copilot-agent.test.tsx
+++ b/providers/agents/copilot/tests/copilot-agent.test.tsx
@@ -172,7 +172,7 @@ describe("copilotAgent()", () => {
       )
     ).rejects.toThrow('Agent "copilot"')
 
-    expect(mcpServerName).toMatch(/^aml_[a-f0-9]{32}$/)
+    expect(mcpServerName).toBe("tools")
     expect(prompts).toHaveLength(2)
     expect(prompts[0]).toContain("<SYSTEM>\nFollow the authored system.\n</SYSTEM>")
     expect(prompts[0]).toContain(`- copilot_proof: ${mcpServerName}-copilot_proof`)

--- a/providers/agents/copilot/tests/copilot-agent.test.tsx
+++ b/providers/agents/copilot/tests/copilot-agent.test.tsx
@@ -172,7 +172,7 @@ describe("copilotAgent()", () => {
       )
     ).rejects.toThrow('Agent "copilot"')
 
-    expect(mcpServerName).toBe("tools")
+    expect(mcpServerName).toMatch(/^tools_[0-9a-f]{12}$/u)
     expect(prompts).toHaveLength(2)
     expect(prompts[0]).toContain("<SYSTEM>\nFollow the authored system.\n</SYSTEM>")
     expect(prompts[0]).toContain(`- copilot_proof: ${mcpServerName}-copilot_proof`)

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -32,6 +32,10 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
     return this.#options.directory
   }
 
+  get reservedMcpServerNames(): readonly string[] {
+    return Object.freeze(Object.keys(configTable(this.#options.config.mcp)))
+  }
+
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {
     const configuration: NonNullable<AcpAgentLaunch["configuration"]>[number][] = []
     const initialPromptSections: string[] = []

--- a/providers/agents/opencode/src/opencode-agent.ts
+++ b/providers/agents/opencode/src/opencode-agent.ts
@@ -33,7 +33,7 @@ class OpenCodeAcpProfile implements AcpAgentProfile<"opencode"> {
   }
 
   get reservedMcpServerNames(): readonly string[] {
-    return Object.freeze(Object.keys(configTable(this.#options.config.mcp)))
+    return Object.keys(configTable(this.#options.config.mcp))
   }
 
   createLaunch(context: Readonly<AcpAgentLaunchContext>): Readonly<AcpAgentLaunch> {

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -7,9 +7,11 @@ import path from "node:path"
 import {
   Agent,
   AmlRuntime,
+  defineMcpServer,
   defineTool,
   evaluate,
   FollowUp,
+  Mcp,
   Sandbox,
   Skill,
   Tool,
@@ -246,13 +248,22 @@ describe("opencodeAgent()", () => {
   })
 
   it("names generated OpenCode MCP tools in structured turns", async () => {
+    let mcpServerNames: readonly string[] = []
     const prompts: string[] = []
     const sandboxProvider = new DeterministicSandboxProvider({
       exec: command => ({ exitCode: 0, stderr: "", stdout: command === "pwd" ? "/sandbox/repository\n" : "" }),
       spawn(command) {
         if (command === "node") return relayFixtureProcess()
-        return acpFixtureProcess(prompt => prompts.push(prompt))
+        return acpFixtureProcess(prompt => prompts.push(prompt), {
+          onMcpServers(servers) {
+            mcpServerNames = servers.map(server => server.name)
+          },
+        })
       },
+    })
+    const collidingServer = defineMcpServer({
+      name: "tools",
+      transport: { type: "streamable-http", url: "https://example.test/mcp" },
     })
     const Result = z.object({ proof: z.string() })
     const readEvidence = defineTool({
@@ -266,6 +277,7 @@ describe("opencodeAgent()", () => {
       return JSON.stringify(
         await evaluate(
           <Agent system="Follow the system.">
+            <Mcp use={collidingServer} />
             <Tool use={readEvidence} />
             Submit proof.
           </Agent>,
@@ -275,7 +287,13 @@ describe("opencodeAgent()", () => {
     }
 
     await expect(
-      new AmlRuntime({ agentProvider: opencodeAgent() }).evaluate(
+      new AmlRuntime({
+        agentProvider: opencodeAgent({
+          config: {
+            mcp: { tools_2: { type: "remote", url: "https://example.test/native-mcp" } },
+          },
+        }),
+      }).evaluate(
         <Sandbox provider={sandboxProvider}>
           <StructuredResult />
         </Sandbox>
@@ -283,11 +301,12 @@ describe("opencodeAgent()", () => {
     ).rejects.toThrow('Agent "opencode"')
 
     expect(prompts).toHaveLength(2)
+    expect(mcpServerNames).toEqual(["tools", "tools_3"])
     expect(prompts[0]).toMatch(
-      /^<SYSTEM>\nFollow the system\.\n<\/SYSTEM>\n\nAML JavaScript Tools use these OpenCode MCP tool names:\n- read_evidence: aml_[a-f0-9]+_read_evidence\n\nSubmit proof\.\n\nCall the OpenCode MCP tool "aml_[a-f0-9]+_aml_submit_result"/u
+      /^<SYSTEM>\nFollow the system\.\n<\/SYSTEM>\n\nAML JavaScript Tools use these OpenCode MCP tool names:\n- read_evidence: tools_3_read_evidence\n\nSubmit proof\.\n\nCall the OpenCode MCP tool "tools_3_aml_submit_result"/u
     )
     expect(prompts[1]).toMatch(
-      /^The previous turn ended without submitting a valid structured result\.\n\nCall the OpenCode MCP tool "aml_[a-f0-9]+_aml_submit_result"/u
+      /^The previous turn ended without submitting a valid structured result\.\n\nCall the OpenCode MCP tool "tools_3_aml_submit_result"/u
     )
     expect(prompts[1]).toContain('"proof"')
   })
@@ -380,6 +399,7 @@ function acpFixtureProcess(
     readonly advertisedModels?: readonly string[]
     readonly applyModel?: boolean
     readonly currentModel?: string
+    readonly onMcpServers?: (servers: readonly { readonly name: string }[]) => void
     readonly onModel?: (value: string) => void
   } = {}
 ): Readonly<SandboxProcess> {
@@ -403,10 +423,13 @@ function acpFixtureProcess(
       agentCapabilities: { mcpCapabilities: { http: true } },
       protocolVersion: params.protocolVersion,
     }))
-    .onRequest(methods.agent.session.new, () => ({
-      configOptions: configOptions(),
-      sessionId: "opencode-test-session",
-    }))
+    .onRequest(methods.agent.session.new, ({ params }) => {
+      options.onMcpServers?.(params.mcpServers)
+      return {
+        configOptions: configOptions(),
+        sessionId: "opencode-test-session",
+      }
+    })
     .onRequest(methods.agent.session.setConfigOption, ({ params }) => {
       if (params.configId === "model" && typeof params.value === "string") {
         if (options.applyModel !== false) currentModel = params.value

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -301,12 +301,21 @@ describe("opencodeAgent()", () => {
     ).rejects.toThrow('Agent "opencode"')
 
     expect(prompts).toHaveLength(2)
-    expect(mcpServerNames).toEqual(["tools", "tools_3"])
+    expect(mcpServerNames).toHaveLength(2)
+    expect(mcpServerNames[0]).toBe("tools")
+    expect(mcpServerNames[1]).toMatch(/^tools_[0-9a-f]{12}$/u)
+    const bridgeName = mcpServerNames[1]
     expect(prompts[0]).toMatch(
-      /^<SYSTEM>\nFollow the system\.\n<\/SYSTEM>\n\nAML JavaScript Tools use these OpenCode MCP tool names:\n- read_evidence: tools_3_read_evidence\n\nSubmit proof\.\n\nCall the OpenCode MCP tool "tools_3_aml_submit_result"/u
+      new RegExp(
+        `^<SYSTEM>\\nFollow the system\\.\\n<\\/SYSTEM>\\n\\nAML JavaScript Tools use these OpenCode MCP tool names:\\n- read_evidence: ${bridgeName}_read_evidence\\n\\nSubmit proof\\.\\n\\nCall the OpenCode MCP tool "${bridgeName}_aml_submit_result"`,
+        "u"
+      )
     )
     expect(prompts[1]).toMatch(
-      /^The previous turn ended without submitting a valid structured result\.\n\nCall the OpenCode MCP tool "tools_3_aml_submit_result"/u
+      new RegExp(
+        `^The previous turn ended without submitting a valid structured result\\.\\n\\nCall the OpenCode MCP tool "${bridgeName}_aml_submit_result"`,
+        "u"
+      )
     )
     expect(prompts[1]).toContain('"proof"')
   })

--- a/providers/agents/opencode/tests/opencode-agent.test.tsx
+++ b/providers/agents/opencode/tests/opencode-agent.test.tsx
@@ -261,8 +261,8 @@ describe("opencodeAgent()", () => {
         })
       },
     })
-    const collidingServer = defineMcpServer({
-      name: "tools",
+    const projectServer = defineMcpServer({
+      name: "project",
       transport: { type: "streamable-http", url: "https://example.test/mcp" },
     })
     const Result = z.object({ proof: z.string() })
@@ -277,7 +277,7 @@ describe("opencodeAgent()", () => {
       return JSON.stringify(
         await evaluate(
           <Agent system="Follow the system.">
-            <Mcp use={collidingServer} />
+            <Mcp use={projectServer} />
             <Tool use={readEvidence} />
             Submit proof.
           </Agent>,
@@ -288,9 +288,10 @@ describe("opencodeAgent()", () => {
 
     await expect(
       new AmlRuntime({
+        toolPrefix: "review",
         agentProvider: opencodeAgent({
           config: {
-            mcp: { tools_2: { type: "remote", url: "https://example.test/native-mcp" } },
+            mcp: { native: { type: "remote", url: "https://example.test/native-mcp" } },
           },
         }),
       }).evaluate(
@@ -302,9 +303,8 @@ describe("opencodeAgent()", () => {
 
     expect(prompts).toHaveLength(2)
     expect(mcpServerNames).toHaveLength(2)
-    expect(mcpServerNames[0]).toBe("tools")
-    expect(mcpServerNames[1]).toMatch(/^tools_[0-9a-f]{12}$/u)
-    const bridgeName = mcpServerNames[1]
+    expect(mcpServerNames).toEqual(["project", "review"])
+    const bridgeName = "review"
     expect(prompts[0]).toMatch(
       new RegExp(
         `^<SYSTEM>\\nFollow the system\\.\\n<\\/SYSTEM>\\n\\nAML JavaScript Tools use these OpenCode MCP tool names:\\n- read_evidence: ${bridgeName}_read_evidence\\n\\nSubmit proof\\.\\n\\nCall the OpenCode MCP tool "${bridgeName}_aml_submit_result"`,

--- a/sdk/src/components/agent/acp-agent-provider.ts
+++ b/sdk/src/components/agent/acp-agent-provider.ts
@@ -183,6 +183,7 @@ class AcpAgentProvider<Name extends string> extends AbstractAgentProvider<Name> 
           request.output,
           context,
           request.output === undefined ? undefined : agentStructuredOutputServices(context),
+          request.toolPrefix || "aml",
           [
             ...request.mcpServers.map(server => (server.kind === "named" ? server.name : server.definition.name)),
             ...(this.#profile.reservedMcpServerNames ?? []),

--- a/sdk/src/components/agent/acp-agent-provider.ts
+++ b/sdk/src/components/agent/acp-agent-provider.ts
@@ -126,6 +126,9 @@ export interface AcpAgentProfile<Name extends string> {
   /** Literal provider name exposed by the resulting Agent provider. */
   readonly name: Name
 
+  /** Provider-native MCP names that share the launched Agent's namespace. */
+  readonly reservedMcpServerNames?: readonly string[]
+
   /** Declares that `createLaunch()` maps staged packages into native discovery. */
   readonly skillDiscovery?: "native"
 
@@ -179,7 +182,11 @@ class AcpAgentProvider<Name extends string> extends AbstractAgentProvider<Name> 
           javaScriptTools,
           request.output,
           context,
-          request.output === undefined ? undefined : agentStructuredOutputServices(context)
+          request.output === undefined ? undefined : agentStructuredOutputServices(context),
+          [
+            ...request.mcpServers.map(server => (server.kind === "named" ? server.name : server.definition.name)),
+            ...(this.#profile.reservedMcpServerNames ?? []),
+          ]
         )
         let connection = await bridge.start(context.signal)
 

--- a/sdk/src/components/agent/acp-mcp-bridge.ts
+++ b/sdk/src/components/agent/acp-mcp-bridge.ts
@@ -55,7 +55,8 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     output: AgentOutputRequest | undefined,
     context: AgentExecutionContext,
     outputServices?: Readonly<AgentStructuredOutputServices>,
-    reservedServerNames: Iterable<string> = []
+    reservedServerNames: Iterable<string> = [],
+    createNameNonce: () => string = compactNameNonce
   ) {
     if (tools.some(tool => tool.name === ACP_STRUCTURED_OUTPUT_TOOL_NAME)) {
       throw new TypeError(`AML JavaScript Tool name "${ACP_STRUCTURED_OUTPUT_TOOL_NAME}" is reserved`)
@@ -66,7 +67,7 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     }
 
     this.#context = context
-    this.#name = availableServerName(reservedServerNames)
+    this.#name = availableServerName(reservedServerNames, createNameNonce)
     this.#output = output
     this.#outputServices = outputServices
     this.#tools = new Map(tools.map(tool => [tool.name, tool]))
@@ -361,16 +362,17 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
 /**
  * Keeps the model-facing bridge name readable while avoiding authored MCP names.
  */
-function availableServerName(reservedServerNames: Iterable<string>): string {
+function availableServerName(reservedServerNames: Iterable<string>, createNonce: () => string): string {
   const reserved = new Set(reservedServerNames)
-  const baseName = "tools"
 
-  if (!reserved.has(baseName)) return baseName
-
-  for (let suffix = 2; ; suffix += 1) {
-    const candidate = `${baseName}_${suffix}`
+  for (;;) {
+    const candidate = `tools_${createNonce()}`
     if (!reserved.has(candidate)) return candidate
   }
+}
+
+function compactNameNonce(): string {
+  return randomUUID().replaceAll("-", "").slice(0, 12)
 }
 
 function validationErrorMessage(error: unknown): string {

--- a/sdk/src/components/agent/acp-mcp-bridge.ts
+++ b/sdk/src/components/agent/acp-mcp-bridge.ts
@@ -31,7 +31,7 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
   readonly #authToken = randomUUID()
   readonly #context: AgentExecutionContext
   readonly #http: HttpServer
-  readonly #name = `aml_${randomUUID().replaceAll("-", "")}`
+  readonly #name: string
   readonly #output: AgentOutputRequest | undefined
   readonly #outputServices: Readonly<AgentStructuredOutputServices> | undefined
   readonly #tools: ReadonlyMap<string, AgentJavaScriptTool>
@@ -54,7 +54,8 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     tools: readonly AgentJavaScriptTool[],
     output: AgentOutputRequest | undefined,
     context: AgentExecutionContext,
-    outputServices?: Readonly<AgentStructuredOutputServices>
+    outputServices?: Readonly<AgentStructuredOutputServices>,
+    reservedServerNames: Iterable<string> = []
   ) {
     if (tools.some(tool => tool.name === ACP_STRUCTURED_OUTPUT_TOOL_NAME)) {
       throw new TypeError(`AML JavaScript Tool name "${ACP_STRUCTURED_OUTPUT_TOOL_NAME}" is reserved`)
@@ -65,6 +66,7 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     }
 
     this.#context = context
+    this.#name = availableServerName(reservedServerNames)
     this.#output = output
     this.#outputServices = outputServices
     this.#tools = new Map(tools.map(tool => [tool.name, tool]))
@@ -353,6 +355,21 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     return {
       content: [{ text: "Structured result accepted.", type: "text" as const }],
     }
+  }
+}
+
+/**
+ * Keeps the model-facing bridge name readable while avoiding authored MCP names.
+ */
+function availableServerName(reservedServerNames: Iterable<string>): string {
+  const reserved = new Set(reservedServerNames)
+  const baseName = "tools"
+
+  if (!reserved.has(baseName)) return baseName
+
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${baseName}_${suffix}`
+    if (!reserved.has(candidate)) return candidate
   }
 }
 

--- a/sdk/src/components/agent/acp-mcp-bridge.ts
+++ b/sdk/src/components/agent/acp-mcp-bridge.ts
@@ -55,8 +55,8 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
     output: AgentOutputRequest | undefined,
     context: AgentExecutionContext,
     outputServices?: Readonly<AgentStructuredOutputServices>,
-    reservedServerNames: Iterable<string> = [],
-    createNameNonce: () => string = compactNameNonce
+    name = "aml",
+    reservedServerNames: Iterable<string> = []
   ) {
     if (tools.some(tool => tool.name === ACP_STRUCTURED_OUTPUT_TOOL_NAME)) {
       throw new TypeError(`AML JavaScript Tool name "${ACP_STRUCTURED_OUTPUT_TOOL_NAME}" is reserved`)
@@ -66,8 +66,16 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
       throw new TypeError("AML ACP structured output requires invocation-owned validation services")
     }
 
+    if (typeof name !== "string" || name.length === 0 || name !== name.trim()) {
+      throw new TypeError("AML Tool prefix must be a non-empty normalized string")
+    }
+
     this.#context = context
-    this.#name = availableServerName(reservedServerNames, createNameNonce)
+    if (new Set(reservedServerNames).has(name)) {
+      throw new TypeError(`AML Tool prefix "${name}" conflicts with MCP server "${name}"`)
+    }
+
+    this.#name = name
     this.#output = output
     this.#outputServices = outputServices
     this.#tools = new Map(tools.map(tool => [tool.name, tool]))
@@ -357,22 +365,6 @@ export class AcpMcpBridge implements AcpStructuredOutputController {
       content: [{ text: "Structured result accepted.", type: "text" as const }],
     }
   }
-}
-
-/**
- * Keeps the model-facing bridge name readable while avoiding authored MCP names.
- */
-function availableServerName(reservedServerNames: Iterable<string>, createNonce: () => string): string {
-  const reserved = new Set(reservedServerNames)
-
-  for (;;) {
-    const candidate = `tools_${createNonce()}`
-    if (!reserved.has(candidate)) return candidate
-  }
-}
-
-function compactNameNonce(): string {
-  return randomUUID().replaceAll("-", "").slice(0, 12)
 }
 
 function validationErrorMessage(error: unknown): string {

--- a/sdk/src/components/agent/agent-executor.ts
+++ b/sdk/src/components/agent/agent-executor.ts
@@ -23,6 +23,7 @@ export class AgentExecutor {
   readonly #agentProvider: Readonly<ValidatedAgentProvider> | undefined
   readonly #maxTurnsPerAgent: number
   readonly #system: string
+  readonly #toolPrefix: string
 
   /**
    * Captures runtime-wide Agent defaults and their provider boundary.
@@ -31,14 +32,24 @@ export class AgentExecutor {
     readonly agentProvider?: AgentProvider
     readonly maxTurnsPerAgent: number
     readonly system?: string
+    readonly toolPrefix?: string
   }) {
     if (options.system !== undefined && typeof options.system !== "string") {
       throw new TypeError("system must be a string")
     }
 
+    if (
+      options.toolPrefix !== undefined &&
+      (typeof options.toolPrefix !== "string" ||
+        (options.toolPrefix.length > 0 && options.toolPrefix !== options.toolPrefix.trim()))
+    ) {
+      throw new TypeError("toolPrefix must be an empty or non-empty normalized string")
+    }
+
     this.#agentProvider = options.agentProvider === undefined ? undefined : validateAgentProvider(options.agentProvider)
     this.#maxTurnsPerAgent = options.maxTurnsPerAgent
     this.#system = options.system ?? ""
+    this.#toolPrefix = options.toolPrefix || "aml"
   }
 
   /**
@@ -186,6 +197,7 @@ export class AgentExecutor {
         skills: input.skills,
         systemFragments: input.systemFragments,
         tools: input.tools,
+        toolPrefix: this.#toolPrefix,
         trace: input.trace,
       })
     } catch (cause) {

--- a/sdk/src/components/agent/agent-executor.ts
+++ b/sdk/src/components/agent/agent-executor.ts
@@ -43,7 +43,7 @@ export class AgentExecutor {
       (typeof options.toolPrefix !== "string" ||
         (options.toolPrefix.length > 0 && options.toolPrefix !== options.toolPrefix.trim()))
     ) {
-      throw new TypeError("toolPrefix must be an empty or non-empty normalized string")
+      throw new TypeError("toolPrefix must be empty or a trimmed non-empty string")
     }
 
     this.#agentProvider = options.agentProvider === undefined ? undefined : validateAgentProvider(options.agentProvider)

--- a/sdk/src/components/agent/agent-request-plan.ts
+++ b/sdk/src/components/agent/agent-request-plan.ts
@@ -59,6 +59,7 @@ export class AgentRequestPlan {
     readonly skills: readonly AgentSkill[]
     readonly systemFragments: readonly string[]
     readonly tools: readonly AgentTool[]
+    readonly toolPrefix: string
     readonly trace: AmlTraceIdentity
   }): AgentRequestPlan {
     const systemFragments: string[] = []
@@ -121,6 +122,7 @@ export class AgentRequestPlan {
       system: systemFragments.join("\n"),
       ...(input.props.timeoutMs === undefined ? {} : { timeoutMs: input.props.timeoutMs }),
       tools,
+      toolPrefix: input.toolPrefix,
       trace: input.trace,
     })
     const context: AgentExecutionContext = Object.freeze({

--- a/sdk/src/components/agent/agent-request.ts
+++ b/sdk/src/components/agent/agent-request.ts
@@ -50,6 +50,9 @@ export interface AgentRequest {
   /** Agent-local JavaScript Tool grants in authored order; empty when absent. */
   readonly tools: readonly AgentTool[]
 
+  /** Model-facing MCP server prefix used for invocation-owned JavaScript Tools. */
+  readonly toolPrefix?: string
+
   /**
    * Trace identity assigned by AML to the Agent request.
    *

--- a/sdk/src/core/aml-runtime.ts
+++ b/sdk/src/core/aml-runtime.ts
@@ -325,6 +325,15 @@ export interface AmlRuntimeOptions {
   readonly system?: string
 
   /**
+   * Model-facing prefix for JavaScript Tools bridged through an MCP server.
+   *
+   * Defaults to `"aml"`. An empty string also selects the default. Non-empty
+   * values must be trimmed and must not collide with another MCP server granted
+   * to the same Agent.
+   */
+  readonly toolPrefix?: string
+
+  /**
    * Listener that receives immutable trace events from every evaluation run by
    * this runtime.
    *
@@ -427,6 +436,7 @@ export class AmlRuntime {
       ...(options.agentProvider === undefined ? {} : { agentProvider: options.agentProvider }),
       maxTurnsPerAgent,
       ...(options.system === undefined ? {} : { system: options.system }),
+      ...(options.toolPrefix === undefined ? {} : { toolPrefix: options.toolPrefix }),
     })
     this.#maxAgentCalls = maxAgentCalls
     this.#maxConcurrentAgents = maxConcurrentAgents

--- a/sdk/tests/acp-mcp-bridge.test.ts
+++ b/sdk/tests/acp-mcp-bridge.test.ts
@@ -66,6 +66,8 @@ describe("AcpMcpBridge", () => {
     const client = await connectMcp(connection)
 
     try {
+      expect(connection.name).toBe("tools")
+      expect(connection.headers.Authorization).toMatch(/^Bearer [0-9a-f-]{36}$/u)
       expect(bridge.instruction).toContain("Call aml_submit_result once")
       expect(bridge.instruction).toContain("If the Tool returns an error, correct the result and retry")
       expect(bridge.instruction).toContain("After the Tool accepts a result, do not call it again")
@@ -90,6 +92,18 @@ describe("AcpMcpBridge", () => {
       expect(execute).toHaveBeenCalledOnce()
     } finally {
       await client.close()
+      await bridge.close()
+    }
+  })
+
+  it("uses a compact numeric suffix when authored MCP server names collide", async () => {
+    const context = createAgentExecutionContext()
+    const bridge = new AcpMcpBridge([], undefined, context, undefined, ["tools", "tools_2", "unrelated"])
+    const connection = await bridge.start(context.signal)
+
+    try {
+      expect(connection.name).toBe("tools_3")
+    } finally {
       await bridge.close()
     }
   })

--- a/sdk/tests/acp-mcp-bridge.test.ts
+++ b/sdk/tests/acp-mcp-bridge.test.ts
@@ -66,7 +66,7 @@ describe("AcpMcpBridge", () => {
     const client = await connectMcp(connection)
 
     try {
-      expect(connection.name).toMatch(/^tools_[0-9a-f]{12}$/u)
+      expect(connection.name).toBe("aml")
       expect(connection.headers.Authorization).toMatch(/^Bearer [0-9a-f-]{36}$/u)
       expect(bridge.instruction).toContain("Call aml_submit_result once")
       expect(bridge.instruction).toContain("If the Tool returns an error, correct the result and retry")
@@ -96,24 +96,20 @@ describe("AcpMcpBridge", () => {
     }
   })
 
-  it("regenerates a compact nonce when an authored MCP server name collides", async () => {
+  it("rejects a Tool prefix that conflicts with an MCP server name", () => {
     const context = createAgentExecutionContext()
-    const nonces = ["deadbeefcafe", "cafebabefeed"]
-    const bridge = new AcpMcpBridge(
-      [],
-      undefined,
-      context,
-      undefined,
-      ["tools_deadbeefcafe"],
-      () => nonces.shift() ?? ""
-    )
-    const connection = await bridge.start(context.signal)
 
-    try {
-      expect(connection.name).toBe("tools_cafebabefeed")
-    } finally {
-      await bridge.close()
-    }
+    expect(() => new AcpMcpBridge([], undefined, context, undefined, "review", ["review"])).toThrow(
+      'AML Tool prefix "review" conflicts with MCP server "review"'
+    )
+  })
+
+  it("rejects an invalid Tool prefix", () => {
+    const context = createAgentExecutionContext()
+
+    expect(() => new AcpMcpBridge([], undefined, context, undefined, " review ")).toThrow(
+      "AML Tool prefix must be a non-empty normalized string"
+    )
   })
 
   it("accepts the first valid structured submission and traces later calls as ignored", async () => {

--- a/sdk/tests/acp-mcp-bridge.test.ts
+++ b/sdk/tests/acp-mcp-bridge.test.ts
@@ -66,7 +66,7 @@ describe("AcpMcpBridge", () => {
     const client = await connectMcp(connection)
 
     try {
-      expect(connection.name).toBe("tools")
+      expect(connection.name).toMatch(/^tools_[0-9a-f]{12}$/u)
       expect(connection.headers.Authorization).toMatch(/^Bearer [0-9a-f-]{36}$/u)
       expect(bridge.instruction).toContain("Call aml_submit_result once")
       expect(bridge.instruction).toContain("If the Tool returns an error, correct the result and retry")
@@ -96,13 +96,21 @@ describe("AcpMcpBridge", () => {
     }
   })
 
-  it("uses a compact numeric suffix when authored MCP server names collide", async () => {
+  it("regenerates a compact nonce when an authored MCP server name collides", async () => {
     const context = createAgentExecutionContext()
-    const bridge = new AcpMcpBridge([], undefined, context, undefined, ["tools", "tools_2", "unrelated"])
+    const nonces = ["deadbeefcafe", "cafebabefeed"]
+    const bridge = new AcpMcpBridge(
+      [],
+      undefined,
+      context,
+      undefined,
+      ["tools_deadbeefcafe"],
+      () => nonces.shift() ?? ""
+    )
     const connection = await bridge.start(context.signal)
 
     try {
-      expect(connection.name).toBe("tools_3")
+      expect(connection.name).toBe("tools_cafebabefeed")
     } finally {
       await bridge.close()
     }

--- a/sdk/tests/agent-runtime.test.tsx
+++ b/sdk/tests/agent-runtime.test.tsx
@@ -116,6 +116,22 @@ describe("Agent", () => {
     expect(localProvider.calls[0]?.request.model).toBe("provider/model")
   })
 
+  it("defaults and configures the model-facing Tool prefix", async () => {
+    const provider = new DeterministicAgentProvider()
+
+    await new AmlRuntime({ agentProvider: provider }).evaluate(<Agent>default</Agent>)
+    await new AmlRuntime({ agentProvider: provider, toolPrefix: "" }).evaluate(<Agent>empty</Agent>)
+    await new AmlRuntime({ agentProvider: provider, toolPrefix: "review" }).evaluate(<Agent>custom</Agent>)
+
+    expect(provider.calls.map(call => call.request.toolPrefix)).toEqual(["aml", "aml", "review"])
+  })
+
+  it("rejects a non-normalized Tool prefix", () => {
+    expect(() => new AmlRuntime({ toolPrefix: " review " })).toThrow(
+      "toolPrefix must be an empty or non-empty normalized string"
+    )
+  })
+
   it("normalizes Agent permission overrides into an immutable provider request", async () => {
     const provider = new DeterministicAgentProvider()
 

--- a/sdk/tests/agent-runtime.test.tsx
+++ b/sdk/tests/agent-runtime.test.tsx
@@ -128,7 +128,7 @@ describe("Agent", () => {
 
   it("rejects a non-normalized Tool prefix", () => {
     expect(() => new AmlRuntime({ toolPrefix: " review " })).toThrow(
-      "toolPrefix must be an empty or non-empty normalized string"
+      "toolPrefix must be empty or a trimmed non-empty string"
     )
   })
 


### PR DESCRIPTION
closes #46

## Description

Replaces the invocation-owned ACP MCP server's UUID-shaped model-facing name with a stable, runtime-configurable Tool prefix.

## What changed?

- Adds `AmlRuntimeOptions.toolPrefix`, defaulting omitted or empty values to `aml`.
- Rejects known authored or provider-native MCP server collisions instead of silently changing the configured prefix.
- Keeps the independent random bearer token as the bridge authentication boundary.
- Updates OpenCode and Copilot coverage for compact ordinary Tool and structured-output names.
- Documents the runtime option and provider-specific flattened name shapes.

## Verification

- Confirmed omitted and empty prefixes resolve to `aml`, while a custom `review` prefix reaches the provider request.
- Exercised OpenCode with `review`, confirming ordinary JavaScript Tools and structured output use the configured prefix consistently.
- Confirmed Copilot qualifies ordinary JavaScript Tools and `aml_submit_result` with the default `aml` prefix.
- Confirmed a prefix collision fails clearly before the bridge starts.
- Confirmed the bridge retains a UUID bearer token independently from its model-facing name.

> Stable names guide calls
> Collisions stop at the gate
> Secrets stay unseen
