### PR TITLE
feat(sdk): add AML component authoring types

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -305,6 +305,18 @@ async function CustomerContext() {
 
 All components are asynchronous computations even when their functions do not use the `async` keyword.
 
+The SDK exports `AML` as the concise author-facing alias for the complete renderable-value union. Its merged type-only namespace defines reusable component contracts without adding runtime behavior:
+
+```ts
+type Component<Props extends object = { readonly children?: never }> = (props: Props) => AML
+type PropsWithChildren<Props extends object = Record<never, never>> = Readonly<Props & { readonly children?: AML }>
+type PropsWithRequiredChildren<Props extends object = Record<never, never>> = Readonly<
+  Props & { readonly children: AML }
+>
+```
+
+`AML.Component<Props>` accepts synchronous and asynchronous component implementations because `AML` includes promised renderable values. It never adds children implicitly: the default is a leaf with no custom props, custom `Props` accept only what they declare, and authors opt into optional or required nested content with the corresponding helper. Required children enforce property presence rather than non-empty output, so explicit AML-empty values remain valid. `AmlRenderable` remains the descriptive equivalent of `AML` for compatibility and lower-level contracts.
+
 ### 4.1 Ordinary async semantics
 
 AML invokes a component exactly once for each evaluated occurrence and awaits its result. Reusing the same JSX value in two authored positions creates two evaluated occurrences; AML does not memoize component results by element identity.

--- a/apps/website/src/content/docs/docs/ast.mdx
+++ b/apps/website/src/content/docs/docs/ast.mdx
@@ -34,6 +34,24 @@ const workflow = <Agent model="reviewer">Inspect the change.</Agent>
 
 into a call equivalent to `jsx(Agent, { model: "reviewer", children: "Inspect the change." })`. The returned value is data. Holding it in a variable does not run `<Agent />`.
 
+## Type application components explicitly
+
+Import `AML` as a type when a reusable component benefits from an explicit authoring contract:
+
+```tsx
+import type { AML } from "@aml-jsx/sdk"
+
+type SectionProps = AML.PropsWithRequiredChildren<{
+  readonly title: string
+}>
+
+const Section: AML.Component<SectionProps> = ({ children, title }) => [title, ": ", children]
+
+const workflow: AML = <Section title="Evidence">Inspect the changed files.</Section>
+```
+
+`AML.Component<Props>` accepts synchronous and asynchronous AML results but does not add `children` implicitly. A component with no generic argument is a leaf with no custom props or children; custom props accept children only when they declare them. Use `AML.PropsWithChildren<Props>` for optional nested content or `AML.PropsWithRequiredChildren<Props>` when the JSX author must supply it. Required children may still be `null`, `undefined`, or another AML-empty value. `AmlRenderable` remains available as the descriptive equivalent of `AML`.
+
 ## What the JSX runtime constructs
 
 Internally, the JSX runtime stores a component reference and frozen props in an AML node descriptor. The descriptor class is deliberately not a root-package value export: application code should treat JSX values as `JSX.Element` or `AmlRenderable` and hand them to the runtime. The component function is invoked only while an evaluation owns an active component context.

--- a/examples/src/core/basic.tsx
+++ b/examples/src/core/basic.tsx
@@ -1,8 +1,4 @@
-import type { AmlRenderable } from "@aml-jsx/sdk"
-
-interface SectionProps {
-  readonly children?: AmlRenderable
-}
+import type { AML } from "@aml-jsx/sdk"
 
 /**
  * Demonstrates bottom-up evaluation across ordinary async components.
@@ -13,7 +9,7 @@ export default function BasicExample() {
     return "bottom-up"
   }
 
-  function Section({ children }: SectionProps) {
+  function Section({ children }: AML.PropsWithRequiredChildren): AML {
     return ["AML resolves ", children]
   }
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -26,6 +26,24 @@ const runtime = new AmlRuntime()
 const result = await runtime.evaluate(<Agent provider={opencodeAgent({})}>Summarize this repository.</Agent>)
 ```
 
+## Typing application components
+
+Import `AML` as a type when declaring reusable workflow components. `AML.Component<Props>` accepts synchronous or asynchronous AML values and does not add an implicit `children` prop. Add optional or required children deliberately with the matching props helper:
+
+```tsx
+import type { AML } from "@aml-jsx/sdk"
+
+type SectionProps = AML.PropsWithRequiredChildren<{
+  readonly title: string
+}>
+
+const Section: AML.Component<SectionProps> = ({ children, title }) => [title, ": ", children]
+
+const workflow: AML = <Section title="Evidence">Inspect the changed files.</Section>
+```
+
+`AmlRenderable` remains available as the descriptive equivalent of `AML`.
+
 The built-in coding-agent factories are thin profiles over AML's shared Agent Client Protocol (ACP) session engine:
 
 ```tsx

--- a/sdk/scripts/check-package.ts
+++ b/sdk/scripts/check-package.ts
@@ -171,6 +171,12 @@ for (const entry of Object.values(resolvedEntries)) {
   }
 }
 
+const builtSdk = await import(pathToFileURL(resolvedEntries.index).href)
+
+if ("AML" in builtSdk) {
+  throw new Error("The type-only AML authoring namespace must not add a runtime export")
+}
+
 const {
   Agent: publicAgent,
   AmlRuntime,
@@ -195,7 +201,7 @@ const {
   Script: publicScript,
   Workspace: publicWorkspace,
   WorkspaceConflictError,
-} = (await import(pathToFileURL(resolvedEntries.index).href)) as BuiltSdk
+} = builtSdk as BuiltSdk
 const { Fragment: runtimeFragment, jsx: runtimeJsx } = (await import(
   pathToFileURL(resolvedEntries.jsxRuntime).href
 )) as BuiltJsxRuntime
@@ -461,7 +467,7 @@ try {
   writeFileSync(
     join(copyFixtureDirectory, "consumer.mts"),
     [
-      'import { AmlRuntime, type AmlRenderable } from "@aml-jsx/sdk-a"',
+      'import { AmlRuntime, type AML, type AmlRenderable } from "@aml-jsx/sdk-a"',
       'import type { McpProps, ToolProps } from "@aml-jsx/sdk-a"',
       'import { defineMcpServer, defineTool, evaluate } from "@aml-jsx/sdk-b"',
       'import { createContext, useContext } from "@aml-jsx/sdk-b"',
@@ -470,6 +476,11 @@ try {
       'const foreignNode = jsx(() => "cross-copy", {})',
       "const renderable: AmlRenderable = foreignNode",
       "await new AmlRuntime().evaluate(renderable)",
+      "type WrappedProps = AML.PropsWithRequiredChildren<{ readonly prefix: string }>",
+      "const Wrapped: AML.Component<WrappedProps> = ({ children, prefix }) => [prefix, children]",
+      'const authored: AML = jsx(Wrapped, { children: foreignNode, prefix: "typed:" })',
+      "const authoredOutput = await new AmlRuntime().evaluate(authored)",
+      'if (authoredOutput !== "typed:cross-copy") throw new Error("Packaged AML authoring types are invalid")',
       "await new AmlRuntime().evaluate(",
       '  jsx(async () => `nested:${await evaluate("data")}`, {}),',
       ")",

--- a/sdk/src/core.ts
+++ b/sdk/src/core.ts
@@ -152,7 +152,7 @@ export { ToolOutputError } from "./components/tool/tool-output-error.js"
 
 // Evaluator, JSX value, and trace contracts.
 export type { AmlJsonValue } from "./core/aml-json-value.js"
-export type { AmlRenderable } from "./core/aml-node.js"
+export type { AML, AmlRenderable } from "./core/aml-node.js"
 export { multiline } from "./core/multiline.js"
 export { AmlRuntime, type AmlEvaluationOptions, type AmlRuntimeOptions } from "./core/aml-runtime.js"
 export { EvaluationError } from "./core/evaluation-error.js"

--- a/sdk/src/core/aml-node.ts
+++ b/sdk/src/core/aml-node.ts
@@ -48,6 +48,58 @@ export type AmlRenderable =
 export type AmlComponent<Props = Record<string, unknown>> = (props: Props) => AmlRenderable
 
 /**
+ * Concise author-facing name for any value accepted by the AML evaluator.
+ *
+ * The merged type-only namespace provides component and children helpers
+ * without adding a runtime export. {@link AmlRenderable} remains available as
+ * the descriptive equivalent.
+ */
+export type AML = AmlRenderable
+
+/** Type-only helpers for declaring application-owned AML components and props. */
+export namespace AML {
+  /**
+   * Function component evaluated once when AML reaches its authored node.
+   *
+   * Components may return synchronous or asynchronous AML values. The default
+   * props describe a leaf component: custom props and authored children must be
+   * declared explicitly.
+   */
+  export type Component<
+    Props extends object = {
+      /** Prevents the default leaf-component contract from accepting authored children. */
+      readonly children?: never
+    },
+  > = AmlComponent<Props>
+
+  /**
+   * Adds optional authored children to application-owned component props.
+   *
+   * The resulting props are readonly because AML captures an immutable props
+   * snapshot when JSX constructs the component node.
+   */
+  export type PropsWithChildren<Props extends object = Record<never, never>> = Readonly<
+    Props & {
+      /** Nested AML content, omitted when the component is self-closing. */
+      readonly children?: AML
+    }
+  >
+
+  /**
+   * Adds a required authored-children property to application-owned component props.
+   *
+   * Required means the JSX author must provide the property. The child may
+   * still be an AML-empty value such as `null` or `undefined`.
+   */
+  export type PropsWithRequiredChildren<Props extends object = Record<never, never>> = Readonly<
+    Props & {
+      /** Nested AML content that must be supplied by the JSX author. */
+      readonly children: AML
+    }
+  >
+}
+
+/**
  * Immutable component props after JSX child normalization.
  *
  * `children` is optional because self-closing components receive no child

--- a/sdk/tests/aml-component-types.test.tsx
+++ b/sdk/tests/aml-component-types.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, expectTypeOf, it } from "vitest"
+
+import type { AML, AmlRenderable } from "../src/index.js"
+
+describe("AML component authoring types", () => {
+  it("supports synchronous and asynchronous leaf components without implicit children", () => {
+    const Leaf: AML.Component = () => "leaf"
+    const NamedLeaf: AML.Component<{ readonly name: string }> = ({ name }) => name
+    const AsyncLeaf: AML.Component<{ readonly name: string }> = async ({ name }) => name
+
+    const leaf = <Leaf />
+    const namedLeaf = <NamedLeaf name="named" />
+    const asyncLeaf = <AsyncLeaf name="async" />
+    const renderable: AML = Promise.resolve([leaf, namedLeaf, asyncLeaf])
+
+    // @ts-expect-error default leaf components do not accept authored children
+    const leafWithChildren = <Leaf>child</Leaf>
+    // @ts-expect-error default leaf components do not accept custom props
+    const leafWithProps = <Leaf name="unexpected" />
+    // @ts-expect-error custom props do not imply a children prop
+    const namedLeafWithChildren = <NamedLeaf name="named">child</NamedLeaf>
+
+    expectTypeOf<AML>().toEqualTypeOf<AmlRenderable>()
+    expect(renderable).toBeInstanceOf(Promise)
+    expect([leafWithChildren, leafWithProps, namedLeafWithChildren]).toHaveLength(3)
+  })
+
+  it("makes optional and required children explicit", () => {
+    type OptionalProps = AML.PropsWithChildren<{ readonly label: string }>
+    type RequiredProps = AML.PropsWithRequiredChildren<{ readonly label: string }>
+
+    const Optional: AML.Component<OptionalProps> = ({ children, label }) => [label, children]
+    const Required: AML.Component<RequiredProps> = async ({ children, label }) => [label, children]
+
+    const optionalWithoutChildren = <Optional label="optional" />
+    const optionalWithChildren = <Optional label="optional">child</Optional>
+    const requiredWithChildren = <Required label="required">child</Required>
+    const requiredWithEmptyChildren = <Required label="required">{null}</Required>
+
+    // @ts-expect-error required-children props reject a self-closing component
+    const requiredWithoutChildren = <Required label="required" />
+
+    expectTypeOf(optionalWithoutChildren).toMatchTypeOf<AML>()
+    expectTypeOf(optionalWithChildren).toMatchTypeOf<AML>()
+    expectTypeOf(requiredWithChildren).toMatchTypeOf<AML>()
+    expectTypeOf(requiredWithEmptyChildren).toMatchTypeOf<AML>()
+    expect(requiredWithoutChildren).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Description

Adds a type-only `AML` authoring facade so application code can type reusable function components and their child contracts without importing internal node types or widening the runtime package surface. Existing `AmlRenderable` imports remain compatible.

## What changed?

- Export `AML` as the concise alias for every renderable AML value.
- Add `AML.Component`, `AML.PropsWithChildren`, and `AML.PropsWithRequiredChildren` with no implicit children on leaf components.
- Cover synchronous and asynchronous components, rejected undeclared props and children, and explicit empty required children.
- Extend the packaged dual-copy fixture and assert the type-only namespace adds no runtime export.
- Document the authoring contract in the specification, SDK README, website, and maintained basic example.

## Verification

- Confirmed leaf components reject undeclared props and nested children while optional and required helpers accept their intended JSX shapes.
- Confirmed synchronous and asynchronous components compile under TypeScript 6 and the current workspace toolchain.
- Evaluated an `AML`-typed component across two physical package copies and confirmed the runtime has no `AML` value export.
- Inspected the emitted declarations and rendered the updated AST authoring guide.

> Types guard every leaf
> Children enter when declared
> Runtime stays unchanged
